### PR TITLE
Add browser controller skeleton

### DIFF
--- a/mc_node_controller/mc-browser-controller/index.html
+++ b/mc_node_controller/mc-browser-controller/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minecraft Web Controller</title>
+    <style>
+        body {
+            background-color: #1a1a1a;
+            color: white;
+            font-family: sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        h1 {
+            color: #4CAF50;
+        }
+        #controller-container {
+            position: relative;
+            border: 2px solid #555;
+            box-shadow: 0 0 20px rgba(0, 255, 0, 0.2);
+        }
+        canvas {
+            display: block;
+        }
+        #controls {
+            margin-top: 20px;
+        }
+        #stop-recording {
+            padding: 10px 20px;
+            font-size: 16px;
+            background-color: #f44336;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            transition: background-color 0.3s;
+        }
+        #stop-recording:hover {
+            background-color: #d32f2f;
+        }
+    </style>
+</head>
+<body>
+    <h1>Minecraft Browser Controller (MCP Mode)</h1>
+    <div id="controller-container">
+        <canvas id="controller-canvas"></canvas>
+    </div>
+    <div id="controls">
+        <button id="stop-recording">Stop & Download Trajectory</button>
+    </div>
+    <!-- 
+        This assumes you are using a bundler like Webpack, Vite, or Parcel 
+        to compile the TypeScript and create a single bundle file.
+    -->
+    <script type="module" src="./dist/main.js"></script>
+</body>
+</html>

--- a/mc_node_controller/mc-browser-controller/package.json
+++ b/mc_node_controller/mc-browser-controller/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mc-browser-controller",
+  "version": "1.0.0",
+  "description": "A browser-based controller for Minecraft using MCP.",
+  "main": "dist/main.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "keywords": [
+    "minecraft",
+    "mcp",
+    "controller"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "pako": "^2.1.0"
+  }
+}

--- a/mc_node_controller/mc-browser-controller/src/constants.ts
+++ b/mc_node_controller/mc-browser-controller/src/constants.ts
@@ -1,0 +1,28 @@
+// src/constants.ts
+
+/**
+ * Port of mc_pygame_controller/constants.py
+ * Defines shared constants for the application.
+ */
+
+// Window constants
+export const WINDOW_WIDTH = 1600;
+export const WINDOW_HEIGHT = 900;
+export const FPS = 60;
+
+// Colors
+export const BLACK = "rgb(0, 0, 0)";
+export const WHITE = "rgb(255, 255, 255)";
+export const GRAY = "rgb(128, 128, 128)";
+export const LIGHT_GRAY = "rgb(200, 200, 200)";
+export const DARK_GRAY = "rgb(64, 64, 64)";
+export const BLUE = "rgb(0, 100, 255)";
+export const GREEN = "rgb(0, 255, 0)";
+export const RED = "rgb(255, 0, 0)";
+export const YELLOW = "rgb(255, 255, 0)";
+export const ORANGE = "rgb(255, 165, 0)";
+export const PURPLE = "rgb(128, 0, 128)";
+export const CYAN = "rgb(0, 255, 255)";
+export const PINK = "rgb(255, 192, 203)";
+export const BROWN = "rgb(150, 75, 0)";
+export const TEAL = "rgb(0, 150, 75)";

--- a/mc_node_controller/mc-browser-controller/src/controller.ts
+++ b/mc_node_controller/mc-browser-controller/src/controller.ts
@@ -1,0 +1,245 @@
+// src/controller.ts
+
+import { WINDOW_WIDTH, WINDOW_HEIGHT, BLACK, WHITE, RED, BLUE, GREEN, ORANGE, PURPLE, GRAY, YELLOW, DARK_GRAY, BROWN, TEAL } from './constants';
+import { Button, ToggleButton, VirtualJoystick, KeyboardMovement, TouchArea, LookPathVisualizationArea } from './ui';
+import { LookPathTracker } from './look-path-tracker';
+import { MinecraftControllerInterface } from './interface';
+import { Point } from './types';
+
+/**
+ * Port of mc_pygame_controller/controller_base.py
+ * The main controller class that manages the UI, state, and main loop.
+ */
+export class MinecraftController {
+    private canvas: HTMLCanvasElement;
+    private ctx: CanvasRenderingContext2D;
+    private running = true;
+    private mode: 'mcp' = 'mcp'; // Only MCP mode is ported for the browser
+    private sensitivity: number;
+    
+    // UI Elements
+    private movementJoystick: VirtualJoystick;
+    private keyboardMovement: KeyboardMovement;
+    private cameraArea: TouchArea;
+    private lookPathTracker: LookPathTracker;
+    private lookVisualization: LookPathVisualizationArea;
+    private buttons: (Button | ToggleButton)[] = [];
+    private hotbarButtons: Button[] = [];
+    
+    // State
+    private lastMovement: Point = { x: 0, y: 0 };
+    private currentHotbarSlot = 0;
+    private lastHotbarSlot = -1;
+
+    // MCP Integration
+    private mcpExecutor: MinecraftControllerInterface | null = null;
+
+    constructor(canvas: HTMLCanvasElement, sensitivity: number = 5.0) {
+        this.canvas = canvas;
+        this.canvas.width = WINDOW_WIDTH;
+        this.canvas.height = WINDOW_HEIGHT;
+        this.ctx = canvas.getContext('2d')!;
+        this.sensitivity = sensitivity;
+
+        // Init UI
+        this.lookPathTracker = new LookPathTracker(2000, this.sensitivity);
+        this.lookVisualization = new LookPathVisualizationArea({x: 1230, y: 50, width: 350, height: 300});
+        
+        this.movementJoystick = new VirtualJoystick({ x: 150, y: WINDOW_HEIGHT - 200 }, 100);
+        this.keyboardMovement = new KeyboardMovement();
+        this.cameraArea = new TouchArea({ x: 400, y: 50, width: 800, height: 500 });
+        
+        this.setupButtons();
+        this.setupHotbar();
+        
+        this.attachEventListeners();
+    }
+    
+    public setMcpExecutor(executor: MinecraftControllerInterface) {
+        this.mcpExecutor = executor;
+        this.lookPathTracker.set_execution_callback((cmd) => this.mcpExecutor?.captureCommand(cmd));
+    }
+
+    private setupButtons() {
+        const btnW = 100, btnH = 40, startX = 1300, startY = 600, spacing = 50;
+        
+        const createAndAdd = (rect: any, text: string, color: any, isToggle: boolean, onAction: any) => {
+            const btn = isToggle
+                ? new ToggleButton(rect, text, color, WHITE, onAction)
+                : new Button(rect, text, color, WHITE, onAction);
+            this.buttons.push(btn);
+            return btn;
+        };
+
+        createAndAdd({x: startX, y: startY, width: btnW, height: btnH}, "Left Click", RED, false, () => this.handleAction('leftClick'));
+        createAndAdd({x: startX + 110, y: startY, width: btnW, height: btnH}, "Right Click", BLUE, false, () => this.handleAction('rightClick'));
+        createAndAdd({x: startX, y: startY + spacing, width: btnW, height: btnH}, "Jump", GREEN, false, () => this.handleAction('jump'));
+        createAndAdd({x: startX, y: startY + spacing * 2, width: btnW, height: btnH}, "Inventory", GRAY, false, () => this.handleAction('openInventory'));
+        createAndAdd({x: startX + 110, y: startY + spacing, width: btnW, height: btnH}, "Sneak", ORANGE, true, (state) => this.handleAction('sneak', { state }));
+        createAndAdd({x: startX + 110, y: startY + spacing * 2, width: btnW, height: btnH}, "Sprint", PURPLE, true, (state) => this.handleAction('sprint', { state }));
+        createAndAdd({x: startX, y: startY + spacing * 3, width: btnW, height: btnH}, "Drop Item", YELLOW, false, () => this.handleAction('dropItem'));
+        createAndAdd({x: startX + 110, y: startY + spacing * 3, width: btnW, height: btnH}, "Swap Hands", PINK, false, () => this.handleAction('swapHands'));
+        createAndAdd({x: startX, y: startY + spacing * 4, width: btnW * 2 + 10, height: btnH}, "Clear Look Path", BROWN, false, () => this.lookPathTracker.clear_history());
+        createAndAdd({x: startX, y: startY + spacing * 5, width: btnW * 2 + 10, height: btnH}, "Save Demo Step", TEAL, false, () => this.mcpExecutor?.saveDemonstrationStep("User clicked save step"));
+    }
+    
+    private setupHotbar() {
+        const btnW = 50, btnH = 40, startX = 50, hotbarY = WINDOW_HEIGHT - 60, spacing = 55;
+        for (let i = 0; i < 9; i++) {
+            const slot = i;
+            const btn = new Button(
+                { x: startX + i * spacing, y: hotbarY, width: btnW, height: btnH },
+                String(i + 1), DARK_GRAY, WHITE,
+                () => this.handleHotbar(slot)
+            );
+            this.hotbarButtons.push(btn);
+        }
+    }
+
+    private handleHotbar(slot: number) {
+        if (slot !== this.lastHotbarSlot) {
+            this.handleAction('setHotbarSlot', { slot });
+            this.currentHotbarSlot = slot;
+            this.lastHotbarSlot = slot;
+        }
+    }
+
+    private handleAction(tool: string, parameters: any = {}) {
+        const command = { tool, parameters };
+        
+        // Clicks need special handling if we want hold support, but for demo capture, single actions are fine.
+        if (tool === 'leftClick' || tool === 'rightClick' || tool === 'jump') {
+            command.parameters.duration = 'short';
+        }
+        
+        this.mcpExecutor?.captureCommand(command);
+    }
+
+    private attachEventListeners() {
+        const getPos = (e: MouseEvent | TouchEvent): Point => {
+            const rect = this.canvas.getBoundingClientRect();
+            if (e instanceof MouseEvent) {
+                return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+            }
+            const touch = e.touches[0] || e.changedTouches[0];
+            return { x: touch.clientX - rect.left, y: touch.clientY - rect.top };
+        };
+
+        const onDown = (e: MouseEvent | TouchEvent) => {
+            e.preventDefault();
+            const pos = getPos(e);
+            const type = 'mousedown';
+            this.movementJoystick.handleEvent(type, pos);
+            this.cameraArea.handleEvent(type, pos);
+            if (this.cameraArea.isTouching) { this.lookPathTracker.start_mouse_tracking(); }
+            this.buttons.forEach(b => b.handleEvent(type, pos));
+            this.hotbarButtons.forEach(b => b.handleEvent(type, pos));
+        };
+
+        const onUp = (e: MouseEvent | TouchEvent) => {
+            e.preventDefault();
+            const pos = getPos(e);
+            const type = 'mouseup';
+            this.movementJoystick.handleEvent(type, pos);
+            if (this.cameraArea.isTouching) { this.lookPathTracker.stop_mouse_tracking(); }
+            this.cameraArea.handleEvent(type, pos);
+            this.buttons.forEach(b => b.handleEvent(type, pos));
+            this.hotbarButtons.forEach(b => b.handleEvent(type, pos));
+        };
+
+        const onMove = (e: MouseEvent | TouchEvent) => {
+            e.preventDefault();
+            const pos = getPos(e);
+            const type = 'mousemove';
+            this.movementJoystick.handleEvent(type, pos);
+            const lookDelta = this.cameraArea.handleEvent(type, pos);
+            this.lookPathTracker.add_movement(lookDelta.x, lookDelta.y);
+        };
+
+        this.canvas.addEventListener('mousedown', onDown);
+        this.canvas.addEventListener('mouseup', onUp);
+        this.canvas.addEventListener('mousemove', onMove);
+        this.canvas.addEventListener('touchstart', onDown);
+        this.canvas.addEventListener('touchend', onUp);
+        this.canvas.addEventListener('touchmove', onMove);
+        
+        // Keyboard hotkeys
+        window.addEventListener('keydown', (e) => {
+            if (e.key >= '1' && e.key <= '9') {
+                this.handleHotbar(parseInt(e.key) - 1);
+            }
+            if (e.key.toLowerCase() === 'q') this.handleAction('dropItem');
+            if (e.key.toLowerCase() === 'f') this.handleAction('swapHands');
+            if (e.key.toLowerCase() === 'e') this.handleAction('openInventory');
+            if (e.key === ' ') this.handleAction('jump');
+        });
+    }
+    
+    private handleMovement() {
+        const joyMove = this.movementJoystick.handleEvent('mousemove', this.movementJoystick.knobPos);
+        const keyMove = this.keyboardMovement.getMovement();
+        
+        let move = {x: 0, y: 0};
+        if (Math.hypot(joyMove.x, joyMove.y) > 0.1) {
+            move = joyMove;
+        } else if (Math.hypot(keyMove.x, keyMove.y) > 0.1) {
+            move = keyMove;
+        }
+
+        if (Math.hypot(move.x, move.y) > 0.1) {
+            if (JSON.stringify(move) !== JSON.stringify(this.lastMovement)) {
+                 // For human demos, we convert continuous movement into discrete 'walk' commands.
+                 // This is a simplification. A better system might have a start/stopWalk action.
+                 // Here, we'll just send a short walk command.
+                 this.handleAction('walk', { duration: 100, direction: { x: move.x, z: move.y }});
+                 this.lastMovement = move;
+            }
+        } else {
+            this.lastMovement = {x: 0, y: 0};
+        }
+    }
+
+    private draw() {
+        this.ctx.fillStyle = BLACK;
+        this.ctx.fillRect(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+        
+        // Draw all UI elements
+        this.movementJoystick.draw(this.ctx);
+        this.cameraArea.draw(this.ctx);
+        this.lookVisualization.draw(this.ctx, this.lookPathTracker);
+        this.buttons.forEach(b => b.draw(this.ctx));
+        this.hotbarButtons.forEach((b, i) => {
+            b.draw(this.ctx);
+            if (i === this.currentHotbarSlot) {
+                this.ctx.strokeStyle = YELLOW;
+                this.ctx.lineWidth = 3;
+                this.ctx.strokeRect(b.rect.x-2, b.rect.y-2, b.rect.width+4, b.rect.height+4);
+            }
+        });
+        
+        // Draw labels and status
+        this.ctx.fillStyle = WHITE;
+        this.ctx.font = '24px sans-serif';
+        this.ctx.textAlign = 'left';
+        this.ctx.fillText(`Mode: ${this.mode.toUpperCase()}`, 10, 30);
+    }
+    
+    public start() {
+        console.log(`Starting Minecraft Controller in ${this.mode.toUpperCase()} mode...`);
+        this.animationLoop();
+    }
+    
+    private animationLoop = () => {
+        if (!this.running) return;
+
+        this.handleMovement();
+        this.draw();
+        
+        requestAnimationFrame(this.animationLoop);
+    }
+
+    public cleanup() {
+        this.running = false;
+        // Remove event listeners if necessary
+    }
+}

--- a/mc_node_controller/mc-browser-controller/src/conversation.ts
+++ b/mc_node_controller/mc-browser-controller/src/conversation.ts
@@ -1,0 +1,121 @@
+// src/conversation.ts
+import { Message } from './types';
+
+/**
+ * Port of mc_pygame_controller/conversation.py
+ * Manages the conversation state and converts human actions into mock LLM responses
+ * for creating demonstration data.
+ */
+
+// A helper to create a mock OpenAI-like tool call structure
+function createMockToolCall(id: string, name: string, args: any) {
+    return {
+        id,
+        type: 'function',
+        function: {
+            name,
+            arguments: JSON.stringify(args)
+        }
+    };
+}
+ 
+// A helper to create a mock response object
+function createMockResponse(content: string | null, tool_calls: any[] | null) {
+    return {
+        choices: [{
+            message: {
+                content,
+                tool_calls,
+                // Simulate the structure of an OpenAI message object
+                ...(!tool_calls ? {} : {
+                    tool_calls: tool_calls.map(tc => ({
+                        ...tc,
+                        function: {
+                            ...tc.function,
+                            arguments: tc.function.arguments, // Already a string
+                        }
+                    }))
+                })
+            }
+        }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+    };
+}
+
+
+export class ConversationPanel {
+    messages: Message[] = [];
+    capturedActions: { tool: string; parameters: any }[] = [];
+    humanDemoMode: boolean = true;
+
+    captureMcpAction(mcpCommand: { tool: string; parameters: any }) {
+        this.capturedActions.push(mcpCommand);
+        console.log(`📝 Captured action: ${mcpCommand.tool}(${JSON.stringify(mcpCommand.parameters)})`);
+    }
+
+    convertActionsToMockResponse() {
+        if (this.capturedActions.length === 0) {
+            return {
+                content: "I'll explore and take some actions in Minecraft.",
+                tool_calls: null
+            };
+        }
+
+        const actionDescriptions: string[] = [];
+        const tool_calls: any[] = [];
+        this.capturedActions.forEach((action, i) => {
+            const tool_name = action.tool;
+            const params = action.parameters;
+            tool_calls.push(createMockToolCall(`call_${i}_${tool_name}`, tool_name, params));
+
+            switch (tool_name) {
+                case "lookAngle":
+                    actionDescriptions.push(`look around (x: ${params.xAngle}°, y: ${params.yAngle}°)`);
+                    break;
+                case "walk":
+                    actionDescriptions.push(`move forward for ${params.duration}ms`);
+                    break;
+                case "leftClick":
+                    actionDescriptions.push("break/attack with left click");
+                    break;
+                case "rightClick":
+                    actionDescriptions.push("place/use with right click");
+                    break;
+                case "setHotbarSlot":
+                    actionDescriptions.push(`select hotbar slot ${params.slot + 1}`);
+                    break;
+                default:
+                    actionDescriptions.push(`use ${tool_name}`);
+            }
+        });
+
+        let content = "I'll perform some actions.";
+        if (actionDescriptions.length === 1) {
+            content = `I'll ${actionDescriptions[0]} to explore the area.`;
+        } else if (actionDescriptions.length > 1) {
+            const allButLast = actionDescriptions.slice(0, -1).join(', ');
+            content = `I'll ${allButLast} and ${actionDescriptions[actionDescriptions.length - 1]} to navigate and explore.`;
+        }
+        
+        this.capturedActions = []; // Clear after conversion
+        return { content, tool_calls };
+    }
+
+    /**
+     * This is the core of the human demonstration system. Instead of calling a real LLM,
+     * it converts captured human actions into a mock LLM response with tool calls.
+     */
+    async renderMessages(apiParams: any) {
+        if (this.messages) {
+            console.log(`📄 Conversation has ${this.messages.length} messages`);
+        }
+        
+        if (this.humanDemoMode) {
+            const { content, tool_calls } = this.convertActionsToMockResponse();
+            return createMockResponse(content, tool_calls);
+        } else {
+            // Fallback for non-demo mode (not used in this port)
+            return createMockResponse("MCP/Browser mode - no OpenAI call made", null);
+        }
+    }
+}

--- a/mc_node_controller/mc-browser-controller/src/interface.ts
+++ b/mc_node_controller/mc-browser-controller/src/interface.ts
@@ -1,0 +1,147 @@
+// src/interface.ts
+
+import { ConversationPanel } from './conversation';
+import { Message } from './types';
+
+/**
+ * Port of mc_pygame_controller/interface.py
+ * Contains the interface that connects the UI to the demonstration capture logic.
+ */
+
+export class TrajectoryStorage {
+    private currentSession: any | null = null;
+
+    startSession(sessionName: string) {
+        this.currentSession = {
+            session_name: sessionName,
+            timestamp: Date.now(),
+            messages: [],
+        };
+        console.log(`🎬 Started trajectory recording: ${sessionName}`);
+    }
+
+    addStep(userContext: string, mockResponse: any) {
+        if (!this.currentSession) return;
+
+        const userMessage = {
+            role: "user",
+            content: userContext,
+            timestamp: Date.now(),
+        };
+        const assistantMessage = {
+            role: "assistant",
+            content: mockResponse.content,
+            tool_calls: mockResponse.tool_calls,
+            timestamp: Date.now(),
+        };
+        this.currentSession.messages.push(userMessage, assistantMessage);
+
+        if (mockResponse.tool_calls) {
+            for (const toolCall of mockResponse.tool_calls) {
+                const toolResult = {
+                    role: "tool",
+                    content: `Executed ${toolCall.function.name} successfully`,
+                    tool_call_id: toolCall.id,
+                    name: toolCall.function.name,
+                    timestamp: Date.now(),
+                };
+                this.currentSession.messages.push(toolResult);
+            }
+        }
+    }
+
+    endSession(finalResponse?: any): any | null {
+        if (!this.currentSession) return null;
+
+        if (finalResponse && finalResponse.tool_calls) {
+            this.addStep("final actions", finalResponse);
+        }
+
+        const filename = `trajectories/${this.currentSession.session_name}_${this.currentSession.timestamp}.json`;
+        const trajectory = { ...this.currentSession };
+        this.currentSession = null;
+
+        // In the browser, we trigger a download instead of writing to a file.
+        const blob = new Blob([JSON.stringify(trajectory, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        console.log(`💾 Saved trajectory to ${filename} (download prompted)`);
+        return trajectory;
+    }
+}
+
+export class MinecraftControllerInterface {
+    public convPanel: ConversationPanel;
+    public toolsMapping: { [key: string]: Function } = {};
+    private trajectoryStorage: TrajectoryStorage;
+    public controller: any | null = null; // Should be MinecraftController, but causes circular dependency
+
+    constructor(mode: "mcp" = "mcp") {
+        this.convPanel = new ConversationPanel();
+        this.trajectoryStorage = new TrajectoryStorage();
+
+        if (mode === 'mcp') {
+            this.convPanel.humanDemoMode = true;
+            console.log(`🎮 MinecraftControllerInterface initialized in ${mode} mode`);
+        }
+    }
+
+    setController(controller: any) {
+        this.controller = controller;
+        controller.setMcpExecutor(this);
+        console.log("🔗 Controller connected to interface");
+    }
+
+    captureCommand(mcpCommand: { tool: string; parameters: any }) {
+        this.convPanel.captureMcpAction(mcpCommand);
+        // Don't wait for execution to keep UI responsive
+        this.executeCommand(mcpCommand);
+    }
+
+    async executeCommand(action: { tool: string; parameters: any }): Promise<any> {
+        const { tool: toolName, parameters: params } = action;
+        console.log(`🎮 Executing: ${toolName}(${JSON.stringify(params)})`);
+        
+        if (toolName in this.toolsMapping) {
+            try {
+                const result = await this.toolsMapping[toolName](params);
+                console.log(`✅ Executed ${toolName} successfully`);
+                return result;
+            } catch (e: any) {
+                console.error(`❌ Error executing ${toolName}: ${e.message}`);
+                return null;
+            }
+        } else {
+            console.warn(`⚠️ Tool ${toolName} not found in tools_mapping. Available:`, Object.keys(this.toolsMapping));
+            return null;
+        }
+    }
+    
+    startTrajectoryRecording(sessionName: string) {
+        this.trajectoryStorage.startSession(sessionName);
+    }
+    
+    stopTrajectoryRecording() {
+        const mockResponse = this.convPanel.convertActionsToMockResponse();
+        const trajectory = this.trajectoryStorage.endSession(mockResponse);
+        console.log(`🎬 Stopped recording. Trajectory has ${trajectory?.messages.length || 0} messages.`);
+        return trajectory;
+    }
+    
+    saveDemonstrationStep(userContext: string): boolean {
+        if (this.convPanel.capturedActions.length > 0) {
+            const mockResponse = this.convPanel.convertActionsToMockResponse();
+            this.trajectoryStorage.addStep(userContext, mockResponse);
+            console.log(`💾 Saved demonstration step: ${userContext}`);
+            return true;
+        }
+        return false;
+    }
+}

--- a/mc_node_controller/mc-browser-controller/src/look-path-tracker.ts
+++ b/mc_node_controller/mc-browser-controller/src/look-path-tracker.ts
@@ -1,0 +1,171 @@
+// src/look-path-tracker.ts
+
+/**
+ * Port of mc_pygame_controller/look_path.py LookPathTracker
+ * Tracks continuous mouse movement for looking around, segments it into
+ * discrete actions, and converts them into MCP `lookAngle` commands.
+ */
+type Movement = {
+    timestamp: number;
+    movement_x: number;
+    movement_y: number;
+    relative_time: number;
+};
+
+type Position = Movement & { x: number; y: number; };
+
+type McpCommand = {
+    tool: string;
+    parameters: any;
+};
+
+export class LookPathTracker {
+    private movements: Movement[] = [];
+    private positions: Position[] = [];
+    private max_history = 1000;
+    private inactivity_timeout_ms: number;
+    private sensitivity: number;
+    private last_movement_time: number | null = null;
+    private current_stats: any | null = null;
+    private execution_callback: ((command: McpCommand) => void) | null = null;
+
+    private mouse_tracking_active = false;
+
+    constructor(inactivity_timeout_ms = 2000, sensitivity = 5.0) {
+        this.inactivity_timeout_ms = inactivity_timeout_ms;
+        this.sensitivity = sensitivity; // Pixels per degree
+    }
+
+    set_execution_callback(callback: (command: McpCommand) => void) {
+        this.execution_callback = callback;
+        console.log("🔗 LookPathTracker execution callback connected");
+    }
+
+    add_movement(movement_x: number, movement_y: number) {
+        if (movement_x === 0 && movement_y === 0) return;
+        
+        const current_time = Date.now();
+
+        if (this.last_movement_time !== null) {
+            if (current_time - this.last_movement_time > this.inactivity_timeout_ms) {
+                this.execute_accumulated_movement("inactivity_timeout");
+            }
+        }
+        this.last_movement_time = current_time;
+
+        const movement: Movement = {
+            timestamp: current_time,
+            movement_x,
+            movement_y,
+            relative_time: current_time - (this.movements[0]?.timestamp ?? current_time),
+        };
+        this.movements.push(movement);
+
+        const last_pos = this.positions[this.positions.length - 1] ?? { x: 0, y: 0 };
+        const position: Position = {
+            ...movement,
+            x: last_pos.x + movement_x,
+            y: last_pos.y + movement_y,
+        };
+        this.positions.push(position);
+
+        if (this.movements.length > this.max_history) {
+            this.movements.shift();
+            this.positions.shift();
+        }
+
+        this.update_angle_analysis();
+    }
+
+    start_mouse_tracking() {
+        if (!this.mouse_tracking_active) {
+            console.log("🖱️ Started mouse tracking for look path");
+            this.mouse_tracking_active = true;
+            // Do not reset here to allow accumulation across multiple drags if needed,
+            // though typical use is one command per drag.
+        }
+    }
+    
+    stop_mouse_tracking() {
+        if (this.mouse_tracking_active) {
+            console.log("🖱️ Stopped mouse tracking - executing command");
+            this.mouse_tracking_active = false;
+            this.execute_accumulated_movement("mouse_release");
+        }
+    }
+    
+    private execute_accumulated_movement(trigger_reason: string) {
+        if (this.current_stats && this.execution_callback) {
+            const [total_x, total_y] = this.current_stats.total_displacement;
+
+            const xAngle = total_x / this.sensitivity;
+            // Invert Y axis for natural camera control (drag down -> look up)
+            const yAngle = - (total_y / this.sensitivity);
+
+            // Only execute meaningful movements (filter noise)
+            if (Math.abs(xAngle) > 0.2 || Math.abs(yAngle) > 0.2) {
+                const mcp_command: McpCommand = {
+                    tool: "lookAngle",
+                    parameters: {
+                        xAngle: parseFloat(xAngle.toFixed(1)),
+                        yAngle: parseFloat(yAngle.toFixed(1)),
+                        speed: "normal",
+                    },
+                };
+                console.log(`🎯 Executing accumulated look: ${xAngle.toFixed(1)}°, ${yAngle.toFixed(1)}° (reason: ${trigger_reason})`);
+                this.execution_callback(mcp_command);
+            } else {
+                console.log(`🔇 Movement too small to execute: ${xAngle.toFixed(1)}°, ${yAngle.toFixed(1)}°`);
+            }
+        }
+        this.reset_tracking_data();
+    }
+
+    private reset_tracking_data() {
+        this.movements = [];
+        this.positions = [];
+        this.current_stats = null;
+        this.last_movement_time = null;
+    }
+
+    clear_history() {
+        console.log("🗑️ Look path manually cleared");
+        this.execute_accumulated_movement("manual_clear");
+        this.reset_tracking_data();
+    }
+
+    private update_angle_analysis() {
+        if (!this.movements.length) {
+            this.current_stats = null;
+            return;
+        }
+
+        const movement_tuples = this.movements.map(m => [m.movement_x, m.movement_y]);
+        const total_x = movement_tuples.reduce((sum, [mx, my]) => sum + mx, 0);
+        const total_y = movement_tuples.reduce((sum, [mx, my]) => sum + my, 0);
+
+        const overall_angle_rad = Math.atan2(total_y, total_x);
+        const overall_angle_deg = (overall_angle_rad * 180) / Math.PI;
+
+        const total_distance = Math.hypot(total_x, total_y);
+        const path_length = movement_tuples.reduce((sum, [mx, my]) => sum + Math.hypot(mx, my), 0);
+        const efficiency = path_length > 0 ? total_distance / path_length : 0;
+        
+        let compass_angle = (90 - overall_angle_deg + 360) % 360;
+        const directions = ["North", "Northeast", "East", "Southeast", "South", "Southwest", "West", "Northwest"];
+        const direction = directions[Math.round(compass_angle / 45) % 8];
+
+        this.current_stats = {
+            total_displacement: [total_x, total_y],
+            total_distance,
+            overall_angle_deg,
+            path_efficiency: efficiency,
+            num_movements: this.movements.length,
+            compass_direction: direction,
+        };
+    }
+
+    get_current_stats() {
+        return this.current_stats;
+    }
+}

--- a/mc_node_controller/mc-browser-controller/src/main.ts
+++ b/mc_node_controller/mc-browser-controller/src/main.ts
@@ -1,0 +1,103 @@
+// src/main.ts
+
+import { MinecraftController } from './controller';
+import { Server, createToolFunctions } from './mcp-client';
+import { MinecraftControllerInterface } from './interface';
+import { MCPMessageChain } from './message-chain';
+import { McpServerConfig } from './types';
+
+/**
+ * Port of mc_pygame_controller/controller.py (main execution block)
+ * This is the entry point for the browser application.
+ */
+
+class App {
+    private controller: MinecraftController | null = null;
+    private servers: Server[] = [];
+    private interface: MinecraftControllerInterface | null = null;
+
+    constructor() {
+        document.addEventListener('DOMContentLoaded', this.init);
+    }
+
+    private init = async () => {
+        const canvas = document.getElementById('controller-canvas') as HTMLCanvasElement;
+        if (!canvas) {
+            console.error("Canvas element with id 'controller-canvas' not found.");
+            return;
+        }
+
+        try {
+            // -- Server Configuration --
+            // In a real app, this would come from a config file or user input.
+            // NOTE: The MCP server must be running and accessible from the browser,
+            // with CORS enabled for the client's origin.
+            const serverConfigs: McpServerConfig[] = [
+                {
+                    name: "minecraft-controller-sse",
+                    url: "http://localhost:8000", // URL of the MCP server
+                }
+            ];
+            
+            this.servers = serverConfigs.map(cfg => new Server(cfg.name, cfg));
+
+            // -- Initialize Servers --
+            console.log("🔧 Initializing MCP servers...");
+            await Promise.all(this.servers.map(s => s.initialize()));
+            console.log("✅ All servers initialized.");
+
+            // -- Create Tools --
+            const { toolSchemas, toolMapping } = await createToolFunctions(this.servers);
+
+            // -- Setup Chain and Interface --
+            this.interface = new MinecraftControllerInterface('mcp');
+            this.interface.toolsMapping = toolMapping;
+
+            const chain = new MCPMessageChain({ verbose: true })
+                .withTools(toolSchemas, toolMapping)
+                .system(
+`You are a *very* ambitious minecraft player.
+Your goal is to find and aquire dirt, wood, stone, iron and diamonds. All in your quest to kill the Ender dragon.
+Follow Minecraft progression - wood first for tools, then stone, then dig deep for iron and diamonds.
+You are autonomous and you can do anything you want.
+I suggest making rotations of plus/minus 45 degrees at a time.
+Craft wooden tools before trying to mine harder materials like stone or terracotta (remember that they take a while to mine).
+Look for surface stone exposures, caves, or ravines rather than digging through hard blocks with bare hands
+Don't call multiple tools at once.`
+                )
+                .clone({ persistentInterface: this.interface }); // Set the interface for the chain
+
+            // -- Setup Controller --
+            this.controller = new MinecraftController(canvas, 5.0);
+            this.interface.setController(this.controller);
+            this.controller.start();
+            
+            this.interface.startTrajectoryRecording("human_demo_session");
+            
+            // Add a button to stop recording and download the trajectory
+            const stopButton = document.getElementById('stop-recording');
+            if (stopButton) {
+                stopButton.onclick = () => {
+                    if (this.interface) {
+                        this.interface.stopTrajectoryRecording();
+                    }
+                };
+            }
+
+        } catch (error) {
+            console.error("🔥 Failed to initialize the application:", error);
+            // Cleanup servers if initialization fails
+            await this.cleanup();
+        }
+    }
+
+    private async cleanup() {
+        console.log("🔧 Cleaning up servers...");
+        for (const server of this.servers) {
+            await server.cleanup();
+        }
+    }
+}
+
+// Instantiate the app
+new App();

--- a/mc_node_controller/mc-browser-controller/src/mcp-client.ts
+++ b/mc_node_controller/mc-browser-controller/src/mcp-client.ts
@@ -1,0 +1,160 @@
+// src/mcp-client.ts
+
+import { McpServerConfig, McpTool } from "./types";
+
+/**
+ * Port of mc_pygame_controller/mcp_client.py
+ * A browser-compatible MCP client that communicates via HTTP/SSE.
+ * It does not support stdio transport, which is unavailable in browsers.
+ */
+class Tool implements McpTool {
+  name: string;
+  description: string;
+  inputSchema: any;
+
+  constructor(name: string, description: string, inputSchema: any) {
+    this.name = name;
+    this.description = description;
+    this.inputSchema = inputSchema;
+  }
+
+  toOpenAiSchema() {
+    return {
+      type: "function",
+      function: {
+        name: this.name,
+        description: this.description,
+        parameters: this.inputSchema,
+      },
+    };
+  }
+}
+
+export class Server {
+  public name: string;
+  public config: McpServerConfig;
+  public session: { initialized: boolean } | null = null;
+  // In a real implementation, an EventSource would be stored here for SSE notifications.
+
+  constructor(name: string, config: McpServerConfig) {
+    this.name = name;
+    this.config = config;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      // In browser, initialization might mean fetching server info or opening a connection.
+      // We'll simulate this with a GET request to the server's root.
+      const response = await fetch(this.config.url);
+      if (!response.ok) {
+        throw new Error(`Server at ${this.config.url} is not available.`);
+      }
+      const serverInfo = await response.json();
+      console.log(`✅ Connected to MCP server: ${serverInfo.name} v${serverInfo.version}`);
+      this.session = { initialized: true };
+    } catch (e) {
+      console.error(`Error initializing server ${this.name}:`, e);
+      await this.cleanup();
+      throw e;
+    }
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    if (!this.session) throw new Error(`Server ${this.name} not initialized`);
+
+    const response = await fetch(`${this.config.url}/tools`);
+    if (!response.ok) throw new Error(`Failed to list tools from ${this.name}`);
+    
+    // The MCP spec returns a JSON array where the tool list is a tuple ["tools", [...]].
+    const toolsResponse = await response.json();
+    const toolList = toolsResponse.find((item: any) => Array.isArray(item) && item[0] === 'tools');
+
+    if (!toolList) return [];
+
+    return toolList[1].map((t: any) => new Tool(t.name, t.description, t.inputSchema));
+  }
+  
+  async executeTool(toolName: string, args: any, retries: number = 2, delay: number = 1000): Promise<any> {
+      if (!this.session) throw new Error(`Server ${this.name} not initialized`);
+
+      let attempt = 0;
+      while(attempt < retries) {
+          try {
+              console.log(`Executing ${toolName} with args:`, args);
+              const response = await fetch(`${this.config.url}/tools/${toolName}/call`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(args),
+              });
+
+              if (!response.ok) {
+                  const errorBody = await response.text();
+                  throw new Error(`Tool call failed with status ${response.status}: ${errorBody}`);
+              }
+
+              const result = await response.json();
+
+              // MCP returns results in a specific format, e.g., ["ok", { content: [...] }]
+              if (Array.isArray(result) && result[0] === 'ok') {
+                return result[1]; // Return the payload
+              } else if (Array.isArray(result) && result[0] === 'error') {
+                throw new Error(result[1]?.message || "Unknown tool execution error");
+              }
+              return result; // Fallback for non-standard responses
+          } catch(e) {
+              attempt++;
+              console.warn(`Error executing tool: ${e}. Attempt ${attempt} of ${retries}.`);
+              if (attempt < retries) {
+                  await new Promise(resolve => setTimeout(resolve, delay));
+              } else {
+                  console.error("Max retries reached. Failing.");
+                  throw e;
+              }
+          }
+      }
+  }
+
+  async cleanup(): Promise<void> {
+    console.log(`Cleaning up server: ${this.name}`);
+    // Close EventSource connection if it exists.
+    this.session = null;
+  }
+}
+
+// Port of mcp_client.py:create_tool_functions
+export async function createToolFunctions(servers: Server[]): Promise<{ toolSchemas: any[], toolMapping: { [key: string]: Function } }> {
+  const toolSchemas: any[] = [];
+  const toolMapping: { [key: string]: Function } = {};
+
+  for (const server of servers) {
+    const tools = await server.listTools();
+    for (const tool of tools) {
+      toolSchemas.push(tool.toOpenAiSchema());
+      
+      toolMapping[tool.name] = async (args: any) => {
+          try {
+              const result = await server.executeTool(tool.name, args);
+              // Handle CallToolResult properly
+              if (result && result.content) {
+                  if (Array.isArray(result.content) && result.content.length > 0) {
+                      return {
+                          content: result.content.map((item: any) => ({
+                              type: item.type || 'text',
+                              text: item.text,
+                              data: item.data,
+                              mimeType: item.mimeType,
+                          }))
+                      };
+                  } else {
+                      return String(result.content);
+                  }
+              }
+              return String(result);
+          } catch (e: any) {
+              return `Error executing tool ${tool.name}: ${e.message}`;
+          }
+      };
+    }
+  }
+  return { toolSchemas, toolMapping };
+}

--- a/mc_node_controller/mc-browser-controller/src/message-chain.ts
+++ b/mc_node_controller/mc-browser-controller/src/message-chain.ts
@@ -1,0 +1,211 @@
+// src/message-chain.ts
+
+import { Message } from "./types";
+import { MinecraftControllerInterface } from "./interface";
+import { resolveMultimodalArgs, resolveMultimodalOutput } from './chain-utils';
+
+/**
+ * Port of mc_pygame_controller/chain.py
+ * An immutable-style message chaining class to manage conversation state
+ * and orchestrate the agent's think-act loop.
+ */
+
+interface MCPMessageChainOptions {
+    messages?: readonly Message[];
+    systemPrompt?: string | null;
+    toolsList?: any[];
+    toolsMapping?: { [key: string]: Function };
+    persistentInterface?: MinecraftControllerInterface;
+    maxTokens?: number;
+    verbose?: boolean;
+    metricList?: any[];
+    responseList?: any[];
+}
+
+export class MCPMessageChain {
+    public readonly messages: readonly Message[];
+    public readonly systemPrompt: string | null;
+    public readonly toolsList: any[];
+    public readonly toolsMapping: { [key: string]: Function };
+    public readonly persistentInterface: MinecraftControllerInterface | null;
+    public readonly maxTokens: number;
+    public readonly verbose: boolean;
+    public readonly metricList: any[];
+    public readonly responseList: any[];
+
+    constructor(options: MCPMessageChainOptions = {}) {
+        this.messages = options.messages || [];
+        this.systemPrompt = options.systemPrompt || null;
+        this.toolsList = options.toolsList || [];
+        this.toolsMapping = options.toolsMapping || {};
+        this.persistentInterface = options.persistentInterface || null;
+        this.maxTokens = options.maxTokens || 4096;
+        this.verbose = options.verbose ?? false;
+        this.metricList = options.metricList || [];
+        this.responseList = options.responseList || [];
+    }
+    
+    private clone(newOptions: Partial<MCPMessageChainOptions>): MCPMessageChain {
+        return new MCPMessageChain({ ...this, ...newOptions });
+    }
+
+    public quiet() { return this.clone({ verbose: false }); }
+    public verbose() { return this.clone({ verbose: true }); }
+    
+    public withTools(toolsList: any[], toolsMapping: { [key: string]: Function }): MCPMessageChain {
+        return this.clone({ toolsList, toolsMapping });
+    }
+    
+    public system(content: string): MCPMessageChain {
+        return this.clone({ systemPrompt: content });
+    }
+
+    public addMessage(msg: Message): MCPMessageChain {
+        return this.clone({ messages: [...this.messages, msg] });
+    }
+
+    public user(content: Message['content']): MCPMessageChain {
+        return this.addMessage({ role: 'user', content });
+    }
+
+    public bot(content: Message['content'], tool_calls: any[] | null = null): MCPMessageChain {
+        return this.addMessage({ role: 'assistant', content, tool_calls });
+    }
+
+    public tool(content: string, tool_call_id: string, name: string): MCPMessageChain {
+        return this.addMessage({ role: 'tool', content, tool_call_id, name });
+    }
+
+    private serialize(): Message[] {
+        const output: Message[] = [];
+        if (this.systemPrompt) {
+            output.push({ role: 'system', content: this.systemPrompt });
+        }
+        output.push(...this.messages);
+        return output;
+    }
+
+    private parseMetrics(resp: any): any {
+        return {
+            input_tokens: resp.usage?.prompt_tokens ?? 0,
+            output_tokens: resp.usage?.completion_tokens ?? 0,
+            total_tokens: resp.usage?.total_tokens ?? 0,
+        };
+    }
+
+    public async generate(): Promise<MCPMessageChain> {
+        let currentChain: MCPMessageChain = this;
+        
+        while (true) {
+            const msgs = currentChain.serialize();
+            if (!currentChain.persistentInterface) {
+                throw new Error("persistentInterface is not set");
+            }
+
+            const interface_ = currentChain.persistentInterface;
+            interface_.convPanel.messages = msgs;
+            
+            // This is the key part: it gets a mock response from human actions
+            const response = await interface_.convPanel.renderMessages({});
+            
+            const msg = response.choices[0].message;
+            const respContent = msg.content;
+            
+            currentChain = currentChain.clone({
+                metricList: [...currentChain.metricList, currentChain.parseMetrics(response)],
+                responseList: [...currentChain.responseList, respContent],
+            });
+
+            if (msg.tool_calls && msg.tool_calls.length > 0) {
+                currentChain = currentChain.bot(msg.content, msg.tool_calls);
+                if (currentChain.verbose) console.log(`🤖 Bot (thinking): ${msg.content}`);
+                
+                for (const tool_call of msg.tool_calls) {
+                    if (currentChain.verbose) console.log(`Tool call:`, tool_call);
+                    const tool_name = tool_call.function.name;
+                    let tool_args = JSON.parse(tool_call.function.arguments);
+                    
+                    tool_args = await resolveMultimodalArgs(tool_args);
+
+                    if (currentChain.toolsMapping && tool_name in currentChain.toolsMapping) {
+                        const tool_response = await currentChain.toolsMapping[tool_name](tool_args);
+                        const resolved_response = await resolveMultimodalOutput(tool_response);
+                        
+                        let tool_response_str = "";
+                        if (typeof resolved_response === 'string') {
+                            tool_response_str = resolved_response;
+                        } else if (resolved_response && resolved_response.multimodal_content) {
+                             const text_parts = resolved_response.multimodal_content.filter((item: any) => item.type === 'text');
+                             tool_response_str = text_parts.map((p: any) => p.text).join(' ') || `Tool ${tool_name} executed successfully.`;
+                        } else {
+                            tool_response_str = JSON.stringify(resolved_response);
+                        }
+                        
+                        if (currentChain.verbose) console.log(`Tool response: ${tool_response_str}`);
+                        currentChain = currentChain.tool(tool_response_str, tool_call.id, tool_name);
+                    } else {
+                        const errorMsg = `Tool '${tool_name}' not found in tools_mapping`;
+                        currentChain = currentChain.tool(errorMsg, tool_call.id, tool_name);
+                    }
+                }
+            } else {
+                break; // No more tool calls, exit loop
+            }
+        }
+        return currentChain;
+    }
+}
+
+/**
+ * Port of mc_pygame_controller/chain_utils.py
+ * Utilities for handling multimodal content in the message chain.
+ */
+
+async function encodeBase64ContentFromUrl(contentUrl: string): Promise<string> {
+    const response = await fetch(contentUrl);
+    if (!response.ok) throw new Error(`Failed to fetch ${contentUrl}`);
+    const blob = await response.blob();
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve((reader.result as string).split(',')[1]);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+    });
+}
+
+export async function resolveMultimodalArgs(args: { [key: string]: any }): Promise<{ [key: string]: any }> {
+    const resolved: { [key: string]: any } = {};
+    for (const key in args) {
+        const value = args[key];
+        if (typeof value === 'string' && value.startsWith('http')) {
+            resolved[key] = await encodeBase64ContentFromUrl(value);
+        } else if (Array.isArray(value)) {
+            resolved[key] = await Promise.all(
+                value.map(v => (typeof v === 'string' && v.startsWith('http')) ? encodeBase64ContentFromUrl(v) : v)
+            );
+        } else {
+            resolved[key] = value;
+        }
+    }
+    return resolved;
+}
+
+export async function resolveMultimodalOutput(output: any): Promise<any> {
+    if (output && Array.isArray(output.content)) {
+        const result: any[] = [];
+        for (const item of output.content) {
+            if (item.type === 'text' && item.text) {
+                result.push({ type: 'text', text: item.text });
+            } else if (item.type === 'image' && item.data) {
+                const mimeType = item.mimeType || 'image/png';
+                const dataUri = `data:${mimeType};base64,${item.data}`;
+                result.push({ type: 'image_url', image_url: { url: dataUri } });
+            }
+        }
+        if (result.length === 1 && result[0].type === 'text') {
+            return result[0].text;
+        }
+        return { multimodal_content: result };
+    }
+    return output;
+}

--- a/mc_node_controller/mc-browser-controller/src/types.ts
+++ b/mc_node_controller/mc-browser-controller/src/types.ts
@@ -1,0 +1,45 @@
+// src/types.ts
+
+/**
+ * Defines common types and interfaces used throughout the application.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type Color = string;
+
+// Port of mc_pygame_controller/conversation.py:Message
+// Represents a single message in a conversation, compatible with OpenAI's format.
+export interface Message {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | (string | { type: string; [key: string]: any })[] | null;
+  tool_calls?: any[] | null;
+  tool_call_id?: string | null;
+  name?: string | null;
+}
+
+// Represents a tool that can be executed by the MCP server.
+export interface McpTool {
+  name: string;
+  description: string;
+  inputSchema: any;
+  toOpenAiSchema: () => any;
+}
+
+// Represents the configuration for an MCP server connection.
+// In the browser, we use a URL instead of a command.
+export interface McpServerConfig {
+  url: string; // Base URL for the MCP server, e.g., 'http://localhost:3000'
+  name: string;
+  [key: string]: any;
+}

--- a/mc_node_controller/mc-browser-controller/src/ui.ts
+++ b/mc_node_controller/mc-browser-controller/src/ui.ts
@@ -1,0 +1,377 @@
+// src/ui.ts
+
+import { Rect, Point, Color, WHITE, GRAY, LIGHT_GRAY, DARK_GRAY, BLUE, GREEN, YELLOW, PURPLE } from "./constants";
+import { LookPathTracker } from './look-path-tracker';
+
+function isPointInRect(point: Point, rect: Rect): boolean {
+  return point.x >= rect.x && point.x <= rect.x + rect.width &&
+         point.y >= rect.y && point.y <= rect.y + rect.height;
+}
+
+export class Button {
+  rect: Rect;
+  text: string;
+  color: Color;
+  textColor: Color;
+  isPressed: boolean = false;
+  font: string = "20px sans-serif";
+  onClick: (() => void) | null = null;
+  
+  constructor(rect: Rect, text: string, color: Color = GRAY, textColor: Color = WHITE, onClick: (() => void) | null = null) {
+    this.rect = rect;
+    this.text = text;
+    this.color = color;
+    this.textColor = textColor;
+    this.onClick = onClick;
+  }
+
+  handleEvent(type: 'mousedown' | 'mouseup' | 'mousemove', pos: Point): boolean {
+    const wasPressed = this.isPressed;
+    
+    if (type === 'mousedown' && isPointInRect(pos, this.rect)) {
+      this.isPressed = true;
+    } else if (type === 'mouseup') {
+      if (this.isPressed && isPointInRect(pos, this.rect)) {
+        if(this.onClick) this.onClick();
+      }
+      this.isPressed = false;
+    }
+    
+    // Return true if the button was just clicked
+    const justClicked = this.isPressed && !wasPressed;
+    if (justClicked && this.onClick) {
+        // For buttons that trigger on press-down, not release
+        // This behavior is specific to how the original python code was structured
+    }
+    return justClicked;
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    const color = this.isPressed ? LIGHT_GRAY : this.color;
+    ctx.fillStyle = color;
+    ctx.fillRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+    ctx.strokeStyle = WHITE;
+    ctx.lineWidth = 2;
+    ctx.strokeRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+
+    ctx.fillStyle = this.textColor;
+    ctx.font = this.font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(this.text, this.rect.x + this.rect.width / 2, this.rect.y + this.rect.height / 2);
+  }
+}
+
+export class ToggleButton extends Button {
+  isToggled: boolean = false;
+
+  constructor(rect: Rect, text: string, color: Color = GRAY, textColor: Color = WHITE, onToggle: ((toggled: boolean) => void) | null = null) {
+    super(rect, text, color, textColor);
+    this.onClick = () => {
+        this.isToggled = !this.isToggled;
+        if(onToggle) onToggle(this.isToggled);
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    const color = this.isToggled ? GREEN : (this.isPressed ? LIGHT_GRAY : this.color);
+    ctx.fillStyle = color;
+    ctx.fillRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+    ctx.strokeStyle = WHITE;
+    ctx.lineWidth = 2;
+    ctx.strokeRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+
+    ctx.fillStyle = this.textColor;
+    ctx.font = this.font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(this.text, this.rect.x + this.rect.width / 2, this.rect.y + this.rect.height / 2);
+  }
+}
+
+export class VirtualJoystick {
+    center: Point;
+    radius: number;
+    knobPos: Point;
+    knobRadius: number;
+    isPressed: boolean = false;
+
+    constructor(center: Point, radius: number) {
+        this.center = center;
+        this.radius = radius;
+        this.knobPos = { ...center };
+        this.knobRadius = radius / 3;
+    }
+
+    handleEvent(type: 'mousedown' | 'mouseup' | 'mousemove', pos: Point): Point {
+        const distance = Math.hypot(pos.x - this.center.x, pos.y - this.center.y);
+
+        if (type === 'mousedown' && distance <= this.radius) {
+            this.isPressed = true;
+        }
+
+        if (type === 'mouseup') {
+            this.isPressed = false;
+        }
+
+        if (!this.isPressed) {
+            this.knobPos = { ...this.center };
+            return { x: 0, y: 0 };
+        }
+
+        if (distance <= this.radius) {
+            this.knobPos = { ...pos };
+        } else {
+            const angle = Math.atan2(pos.y - this.center.y, pos.x - this.center.x);
+            this.knobPos.x = this.center.x + Math.cos(angle) * this.radius;
+            this.knobPos.y = this.center.y + Math.sin(angle) * this.radius;
+        }
+
+        const normX = (this.knobPos.x - this.center.x) / this.radius;
+        const normY = (this.knobPos.y - this.center.y) / this.radius;
+        return { x: normX, y: normY };
+    }
+
+    draw(ctx: CanvasRenderingContext2D) {
+        // Draw outer circle
+        ctx.strokeStyle = this.isPressed ? BLUE : GRAY;
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.arc(this.center.x, this.center.y, this.radius, 0, 2 * Math.PI);
+        ctx.stroke();
+
+        // Draw knob
+        ctx.fillStyle = this.isPressed ? YELLOW : LIGHT_GRAY;
+        ctx.beginPath();
+        ctx.arc(this.knobPos.x, this.knobPos.y, this.knobRadius, 0, 2 * Math.PI);
+        ctx.fill();
+    }
+}
+
+export class KeyboardMovement {
+    private keys: { [key: string]: boolean } = {
+        'w': false, 'a': false, 's': false, 'd': false
+    };
+
+    constructor() {
+        window.addEventListener('keydown', (e) => this.handleKey(e.key, true));
+        window.addEventListener('keyup', (e) => this.handleKey(e.key, false));
+    }
+
+    private handleKey(key: string, isPressed: boolean) {
+        const lowerKey = key.toLowerCase();
+        if (lowerKey in this.keys) {
+            this.keys[lowerKey] = isPressed;
+        }
+    }
+    
+    isAnyKeyPressed(): boolean {
+        return this.keys['w'] || this.keys['a'] || this.keys['s'] || this.keys['d'];
+    }
+
+    getMovement(): Point {
+        let normX = 0;
+        let normY = 0;
+
+        if (this.keys['a']) normX -= 1;
+        if (this.keys['d']) normX += 1;
+        if (this.keys['w']) normY -= 1; // W = forward = negative Y
+        if (this.keys['s']) normY += 1; // S = backward = positive Y
+
+        const length = Math.hypot(normX, normY);
+        if (length > 1) {
+            normX /= length;
+            normY /= length;
+        }
+
+        return { x: normX, y: normY };
+    }
+}
+
+export class TouchArea {
+  rect: Rect;
+  private lastMousePos: Point | null = null;
+  isTouching: boolean = false;
+
+  constructor(rect: Rect) {
+    this.rect = rect;
+  }
+
+  handleEvent(type: 'mousedown' | 'mouseup' | 'mousemove', pos: Point): Point {
+    const touching = isPointInRect(pos, this.rect);
+    
+    if (type === 'mousedown' && touching) {
+        this.isTouching = true;
+        this.lastMousePos = { ...pos };
+        return { x: 0, y: 0 };
+    }
+
+    if (type === 'mouseup') {
+        this.isTouching = false;
+        this.lastMousePos = null;
+    }
+    
+    if (this.isTouching && type === 'mousemove') {
+        if(this.lastMousePos) {
+            const deltaX = pos.x - this.lastMousePos.x;
+            const deltaY = pos.y - this.lastMousePos.y;
+            this.lastMousePos = { ...pos };
+            return { x: deltaX, y: deltaY };
+        }
+    }
+    
+    return { x: 0, y: 0 };
+  }
+  
+  draw(ctx: CanvasRenderingContext2D) {
+    const color = this.isTouching ? GREEN : DARK_GRAY;
+    
+    ctx.fillStyle = this.isTouching ? 'rgba(0, 64, 0, 0.5)' : 'rgba(32, 32, 32, 0.5)';
+    ctx.fillRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+    
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 3;
+    ctx.strokeRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+
+    ctx.fillStyle = WHITE;
+    ctx.font = "28px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("Camera Look Area - Drag to Look Around", this.rect.x + this.rect.width / 2, this.rect.y + this.rect.height / 2);
+  }
+}
+
+export class LookPathVisualizationArea {
+    rect: Rect;
+    private origin: Point;
+    private scale = 0.5;
+    private gridSize = 20;
+    private font = "16px sans-serif";
+
+    constructor(rect: Rect) {
+        this.rect = rect;
+        this.origin = {
+            x: rect.x + rect.width / 2,
+            y: rect.y + rect.height / 2
+        };
+    }
+
+    draw(ctx: CanvasRenderingContext2D, pathTracker: LookPathTracker) {
+        ctx.save();
+        
+        // Background
+        ctx.fillStyle = 'rgba(20, 20, 20, 0.8)';
+        ctx.fillRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+        ctx.strokeStyle = WHITE;
+        ctx.lineWidth = 2;
+        ctx.strokeRect(this.rect.x, this.rect.y, this.rect.width, this.rect.height);
+
+        this.drawGrid(ctx);
+        this.drawAxes(ctx);
+        this.drawOrigin(ctx);
+
+        if (pathTracker.positions.length > 0) {
+            this.drawPath(ctx, pathTracker.positions);
+        }
+
+        this.drawInfo(ctx, pathTracker);
+
+        ctx.restore();
+    }
+    
+    private drawGrid(ctx: CanvasRenderingContext2D) {
+        ctx.strokeStyle = 'rgba(40, 40, 40, 0.8)';
+        ctx.lineWidth = 1;
+        for (let x = this.rect.x; x < this.rect.x + this.rect.width; x += this.gridSize) {
+            ctx.beginPath();
+            ctx.moveTo(x, this.rect.y);
+            ctx.lineTo(x, this.rect.y + this.rect.height);
+            ctx.stroke();
+        }
+        for (let y = this.rect.y; y < this.rect.y + this.rect.height; y += this.gridSize) {
+            ctx.beginPath();
+            ctx.moveTo(this.rect.x, y);
+            ctx.lineTo(this.rect.x + this.rect.width, y);
+            ctx.stroke();
+        }
+    }
+    
+    private drawAxes(ctx: CanvasRenderingContext2D) {
+        ctx.strokeStyle = GRAY;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(this.rect.x, this.origin.y);
+        ctx.lineTo(this.rect.x + this.rect.width, this.origin.y);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(this.origin.x, this.rect.y);
+        ctx.lineTo(this.origin.x, this.rect.y + this.rect.height);
+        ctx.stroke();
+    }
+    
+    private drawOrigin(ctx: CanvasRenderingContext2D) {
+        ctx.fillStyle = RED;
+        ctx.beginPath();
+        ctx.arc(this.origin.x, this.origin.y, 6, 0, 2 * Math.PI);
+        ctx.fill();
+        ctx.strokeStyle = WHITE;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
+    
+    private drawPath(ctx: CanvasRenderingContext2D, positions: any[]) {
+        if (positions.length < 2) return;
+        
+        ctx.strokeStyle = CYAN;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        const startX = this.origin.x + positions[0].x * this.scale;
+        const startY = this.origin.y + positions[0].y * this.scale;
+        ctx.moveTo(startX, startY);
+
+        for (const pos of positions) {
+             const x = this.origin.x + pos.x * this.scale;
+             const y = this.origin.y + pos.y * this.scale;
+             ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+        
+        // Draw current position marker
+        const lastPos = positions[positions.length - 1];
+        const lastX = this.origin.x + lastPos.x * this.scale;
+        const lastY = this.origin.y + lastPos.y * this.scale;
+        ctx.fillStyle = PURPLE;
+        ctx.beginPath();
+        ctx.arc(lastX, lastY, 5, 0, 2 * Math.PI);
+        ctx.fill();
+    }
+
+    private drawInfo(ctx: CanvasRenderingContext2D, pathTracker: LookPathTracker) {
+        const stats = pathTracker.get_current_stats();
+        const infoRect = { x: this.rect.x + 5, y: this.rect.y + 5, width: 200, height: 180 };
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+        ctx.fillRect(infoRect.x, infoRect.y, infoRect.width, infoRect.height);
+        
+        ctx.fillStyle = WHITE;
+        ctx.font = this.font;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        let yOffset = infoRect.y + 8;
+        const write = (text: string) => {
+            ctx.fillText(text, infoRect.x + 5, yOffset);
+            yOffset += 18;
+        };
+
+        if (!stats) {
+            write("No movements recorded");
+            return;
+        }
+
+        write(`Movements: ${stats.num_movements}`);
+        const [totalX, totalY] = stats.total_displacement;
+        write(`Position: (${totalX.toFixed(0)}, ${totalY.toFixed(0)})`);
+        write(`Overall: ${stats.overall_angle_deg.toFixed(1)}° (${stats.compass_direction})`);
+        write(`Efficiency: ${(stats.path_efficiency * 100).toFixed(1)}%`);
+    }
+}

--- a/mc_node_controller/mc-browser-controller/tsconfig.json
+++ b/mc_node_controller/mc-browser-controller/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/mc_node_controller/mc-browser-controller/vite.config.ts
+++ b/mc_node_controller/mc-browser-controller/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist'
+  }
+})


### PR DESCRIPTION
## Summary
- split `mc_node_controller/response.md` into a set of TypeScript sources
- assemble a minimal `mc-browser-controller` project

## Testing
- `npm install` inside `mc_node_controller/mc-browser-controller`
- `npm run build` *(fails: cannot find some names and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68441e7e37b083259c7a046637242eb8