### PR TITLE
Add movement verification docs and stubs

### DIFF
--- a/bug_report.md
+++ b/bug_report.md
@@ -1,0 +1,38 @@
+## Bug Report
+
+Unable to run movement action verification tests.
+
+### Description of problem
+Missing dependencies (`openai`, `mcp` package) and package import issues prevent running `test_phase1.py`.
+
+### Steps to reproduce
+1. Install requirements.
+2. Run `python3 mc_pygame_controller/test_phase1.py`.
+3. Observe `ModuleNotFoundError` for `mcp` and other modules.
+
+### Expected vs actual behavior
+Expected: Tests execute and validate movement actions.
+Actual: Import errors stop execution.
+
+### Console error logs
+See attached console output excerpt below.
+Traceback (most recent call last):
+  File "/workspace/minecraft-web-client/mc_pygame_controller/mode_strategy.py", line 15, in <module>
+    from .async_mcp_executor import AsyncMCPExecutor, MCPActionRequest
+ImportError: attempted relative import with no known parent package
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/workspace/minecraft-web-client/mc_pygame_controller/async_mcp_executor.py", line 8, in <module>
+    from .mcp_client import Server
+ImportError: attempted relative import with no known parent package
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/workspace/minecraft-web-client/mc_pygame_controller/test_phase1.py", line 14, in <module>
+    from mode_strategy import PygameModeStrategy
+  File "/workspace/minecraft-web-client/mc_pygame_controller/mode_strategy.py", line 22, in <module>
+    from async_mcp_executor import AsyncMCPExecutor, MCPActionRequest
+  File "/workspace/minecraft-web-client/mc_pygame_controller/async_mcp_executor.py", line 10, in <module>

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,0 +1,15 @@
+class ClientSession:
+    def __init__(self, read=None, write=None):
+        pass
+    async def initialize(self):
+        pass
+    async def list_tools(self):
+        return []
+    async def call_tool(self, tool_name, arguments):
+        return {"content": "", "status": "success"}
+
+class StdioServerParameters:
+    def __init__(self, command=None, args=None, env=None):
+        self.command = command
+        self.args = args
+        self.env = env

--- a/mcp/client/stdio.py
+++ b/mcp/client/stdio.py
@@ -1,0 +1,8 @@
+class DummyStdioClient:
+    async def __aenter__(self):
+        return (None, None)
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+def stdio_client(params):
+    return DummyStdioClient()

--- a/movement_test_results.md
+++ b/movement_test_results.md
@@ -1,0 +1,17 @@
+## WASD Movement Tests
+- [ ] W key triggers walk MCP action
+- [ ] Duration calculated correctly
+- [ ] getBotStatus called after movement
+- Test execution blocked due to missing dependencies.
+
+## Joystick Movement Tests
+- [ ] Joystick drag triggers walk MCP action
+- [ ] Diagonal movements work correctly
+- Test execution blocked due to missing dependencies.
+
+## Camera Movement Tests
+- [ ] Mouse drag triggers lookAngle MCP action
+- [ ] Angle calculations are reasonable
+- Test execution blocked due to missing dependencies.
+
+**Note**: Unable to run full tests because required modules (openai, mcp, etc.) are unavailable in the environment.

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,0 +1,5 @@
+class AsyncOpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def __call__(self, *args, **kwargs):
+        return {}

--- a/session_camera_test.json
+++ b/session_camera_test.json
@@ -1,0 +1,4 @@
+{
+  "status": "placeholder",
+  "reason": "No data collected due to missing dependencies"
+}

--- a/session_joystick_test.json
+++ b/session_joystick_test.json
@@ -1,0 +1,4 @@
+{
+  "status": "placeholder",
+  "reason": "No data collected due to missing dependencies"
+}

--- a/session_wasd_test.json
+++ b/session_wasd_test.json
@@ -1,0 +1,4 @@
+{
+  "status": "placeholder",
+  "reason": "No data collected due to missing dependencies"
+}


### PR DESCRIPTION
## Summary
- add stub `mcp` and `openai` modules so tests can import
- provide `movement_test_results.md` and sample session jsons
- document inability to run tests in `bug_report.md`

## Testing
- `python3 mc_pygame_controller/test_phase1.py` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6845ae49073c8325b420e0beedbe2929