### PR TITLE
Add click action verification tests

### DIFF
--- a/tests/test_click_actions.py
+++ b/tests/test_click_actions.py
@@ -1,0 +1,28 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load the module directly from file to avoid running package __init__
+module_path = Path(__file__).resolve().parent.parent / 'mc_pygame_controller' / 'action_converter.py'
+spec = importlib.util.spec_from_file_location('action_converter', module_path)
+action_converter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(action_converter)
+ActionConverter = action_converter.ActionConverter
+
+
+def test_left_click_deduplication():
+    actions = [
+        {"type": "documentMouseEvent", "button": 0, "action": "down"},
+        {"type": "documentMouseEvent", "button": 0, "action": "up"},
+    ]
+    mcp_actions = ActionConverter.convert_pygame_actions_bulk(actions)
+    assert mcp_actions == [{"tool": "leftClick", "parameters": {"duration": "short"}}]
+
+
+def test_right_click_conversion():
+    actions = [
+        {"type": "rightDown"},
+        {"type": "rightUp"},
+    ]
+    mcp_actions = ActionConverter.convert_pygame_actions_bulk(actions)
+    assert mcp_actions == [{"tool": "rightClick", "parameters": {"duration": "short"}}]

--- a/ws_client.py
+++ b/ws_client.py
@@ -1,0 +1,51 @@
+import asyncio
+import json
+import threading
+import websockets
+
+
+class WebSocketClient:
+    """Simple asynchronous WebSocket client used for tests."""
+
+    def __init__(self, uri: str, on_connect=None, on_message=None, on_disconnect=None):
+        self.uri = uri
+        self.on_connect = on_connect
+        self.on_message = on_message
+        self.on_disconnect = on_disconnect
+        self._loop = None
+        self._thread = None
+        self._ws = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def _run_loop(self):
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._connect_loop())
+
+    async def _connect_loop(self):
+        async with websockets.connect(self.uri) as ws:
+            self._ws = ws
+            if self.on_connect:
+                self.on_connect()
+            try:
+                async for message in ws:
+                    if self.on_message:
+                        self.on_message(json.loads(message))
+            finally:
+                if self.on_disconnect:
+                    self.on_disconnect()
+
+    def send(self, data):
+        if self._loop and self._ws:
+            asyncio.run_coroutine_threadsafe(self._ws.send(json.dumps(data)), self._loop)
+
+    async def stop(self):
+        if self._ws:
+            await self._ws.close()
+        if self._loop:
+            self._loop.stop()
+        if self._thread:
+            self._thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- add minimal `ws_client` module for websocket testing
- add unit tests verifying left and right click action conversion

## Testing
- `pytest tests/test_click_actions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ae538fc48325ab397fc4295bbf5b