### PR TITLE
Add sequence tracking verification artifacts

### DIFF
--- a/mc_pygame_controller/phase1_manual.py
+++ b/mc_pygame_controller/phase1_manual.py
@@ -5,6 +5,7 @@ Test script for Phase 1 PygameModeStrategy Enhancement
 Tests the enhanced PygameModeStrategy with MCP integration capabilities.
 """
 
+__test__ = False
 import sys
 import os
 

--- a/sequence_monitor.py
+++ b/sequence_monitor.py
@@ -1,0 +1,37 @@
+"""Utility script to monitor console output for sequence tracking events."""
+import re
+import sys
+import time
+
+
+CREATION_RE = re.compile(r"Started tracking sequence (\S+)")
+COMPLETION_RE = re.compile(r"Sequence (\S+) complete")
+
+
+def monitor_console_output(stream=sys.stdin):
+    sequences = {}
+    for line in stream:
+        line = line.rstrip()
+        print(line)
+        match = CREATION_RE.search(line)
+        if match:
+            sequences[match.group(1)] = time.time()
+            continue
+        match = COMPLETION_RE.search(line)
+        if match:
+            seq_id = match.group(1)
+            start = sequences.pop(seq_id, None)
+            if start:
+                duration = time.time() - start
+                print(f"[monitor] {seq_id} completed in {duration:.2f}s")
+            continue
+        # check for hanging sequences every iteration
+        now = time.time()
+        for seq_id, start in list(sequences.items()):
+            if now - start > 5:
+                print(f"[monitor] warning: {seq_id} incomplete after {now-start:.1f}s")
+                sequences.pop(seq_id)
+
+
+if __name__ == "__main__":
+    monitor_console_output()

--- a/sequence_tracking_report.md
+++ b/sequence_tracking_report.md
@@ -1,0 +1,20 @@
+## Single Action Tests
+- [ ] Single actions create sequences correctly
+- [ ] getBotStatus automatically added to all sequences
+- [ ] Expected response count = actions + 1
+- [ ] Sequences complete successfully
+
+## Multi-Action Tests
+- [ ] Multi-action sequences track all actions
+- [ ] Response counting works for complex sequences
+- [ ] No actions lost in rapid sequences
+
+## getBotStatus Timing Tests
+- [ ] getBotStatus called after every sequence
+- [ ] getBotStatus responses received successfully
+- [ ] No missing getBotStatus calls
+
+## Completion Detection Tests
+- [ ] Sequences complete when all responses received
+- [ ] No sequences left hanging incomplete
+- [ ] Completion timing is reasonable

--- a/tests/test_sequence_tracking.py
+++ b/tests/test_sequence_tracking.py
@@ -1,0 +1,54 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+base = pathlib.Path(__file__).resolve().parent.parent / "mc_pygame_controller"
+
+# Minimal stub for PygameMCPAsyncMessageChain
+class StubChain:
+    def __init__(self):
+        self.messages = []
+
+    def user(self, content):
+        self.messages.append(("user", content))
+        return self
+
+    def bot(self, content="", tool_calls=None):
+        self.messages.append(("assistant", tool_calls))
+        return self
+
+    def tool(self, content="", tool_call_id="", name=""):
+        self.messages.append(("tool", name))
+        return self
+
+    def to_dict(self):
+        return {"messages": self.messages}
+
+sys.modules["chain"] = types.SimpleNamespace(PygameMCPAsyncMessageChain=StubChain)
+
+# Load action_converter so relative import works
+spec_conv = importlib.util.spec_from_file_location("action_converter", base / "action_converter.py")
+conv_module = importlib.util.module_from_spec(spec_conv)
+spec_conv.loader.exec_module(conv_module)
+sys.modules["action_converter"] = conv_module
+
+spec_tracker = importlib.util.spec_from_file_location("action_sequence_tracker", base / "action_sequence_tracker.py")
+tracker_module = importlib.util.module_from_spec(spec_tracker)
+spec_tracker.loader.exec_module(tracker_module)
+ActionSequenceTracker = tracker_module.ActionSequenceTracker
+
+
+def test_sequence_complete_single_action():
+    tracker = ActionSequenceTracker()
+    seq_id = tracker.start_sequence([{"type": "move", "x": 1, "z": 0}], "test")
+    assert tracker.active_sequences[seq_id].expected_responses == 2
+
+    tracker.add_mcp_response(seq_id, {"tool": "walk", "content": "ok"})
+    assert not tracker.is_sequence_complete(seq_id)
+    tracker.add_mcp_response(seq_id, {"tool": "getBotStatus", "content": "status"})
+    assert tracker.is_sequence_complete(seq_id)
+
+    seq = tracker.complete_sequence(seq_id)
+    chain = tracker.build_conversation_chain(seq)
+    assert len(chain.messages) == 3

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,3 +1,5 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import asyncio
 import json
 import websockets

--- a/ws_client.py
+++ b/ws_client.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+import websockets
+
+class WebSocketClient:
+    """Minimal async WebSocket client used for tests."""
+
+    def __init__(self, url: str, on_disconnect=None):
+        self.url = url
+        self.on_disconnect = on_disconnect
+        self._ws = None
+        self._task = None
+
+    def start(self):
+        loop = asyncio.get_event_loop()
+        self._task = loop.create_task(self._connect())
+
+    async def _connect(self):
+        try:
+            async with websockets.connect(self.url) as ws:
+                self._ws = ws
+                async for _ in ws:
+                    pass
+        finally:
+            if self.on_disconnect:
+                self.on_disconnect()
+
+    def send(self, data):
+        if self._ws:
+            asyncio.create_task(self._ws.send(json.dumps(data)))
+
+    async def stop(self):
+        if self._ws:
+            await self._ws.close()
+        if self._task:
+            await self._task


### PR DESCRIPTION
## Summary
- add a minimal async `WebSocketClient` implementation for tests
- provide a console `sequence_monitor.py` utility
- draft `sequence_tracking_report.md` template
- move manual phase1 test out of pytest discovery
- adjust websocket test to ensure `ws_client` can be imported
- add initial test stub for `ActionSequenceTracker`

## Testing
- `pytest -q` *(fails: ImportError in test_sequence_tracking due to package imports)*

------
https://chatgpt.com/codex/tasks/task_e_6845af4486a083258ad16348d381e80c