### PR TITLE
Add integration testing helpers

### DIFF
--- a/verification_tasks/performance_monitor.py
+++ b/verification_tasks/performance_monitor.py
@@ -1,0 +1,40 @@
+import argparse
+import json
+import time
+from pathlib import Path
+
+import psutil
+
+
+def monitor_performance(output: Path, interval: float = 1.0) -> None:
+    """Continuously record CPU and memory usage to ``output``."""
+    data = {
+        "memory_usage": [],
+        "cpu_usage": [],
+        "timestamps": [],
+    }
+
+    def save():
+        output.write_text(json.dumps(data, indent=2))
+
+    try:
+        while True:
+            data["memory_usage"].append(psutil.virtual_memory().percent)
+            data["cpu_usage"].append(psutil.cpu_percent())
+            data["timestamps"].append(time.time())
+            time.sleep(interval)
+            if len(data["timestamps"]) % 60 == 0:
+                save()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Monitor system performance during mc_pygame_controller tests")
+    parser.add_argument("-o", "--output", default="performance_data.json", help="JSON file for collected stats")
+    parser.add_argument("-i", "--interval", type=float, default=1.0, help="Sampling interval in seconds")
+    args = parser.parse_args()
+
+    monitor_performance(Path(args.output), args.interval)

--- a/verification_tasks/stress_test_runner.py
+++ b/verification_tasks/stress_test_runner.py
@@ -1,0 +1,76 @@
+"""Automated stress test helper for mc_pygame_controller.
+
+This script connects to the WebSocket relay used by the controller and
+sends a continuous stream of randomized actions. It is intended as a
+lightweight way to exercise the server during integration testing.
+"""
+
+import argparse
+import asyncio
+import json
+import random
+import time
+from typing import Callable, Dict
+
+import websockets
+
+# Available action generators
+
+ActionGenerator = Callable[[], Dict[str, object]]
+
+
+def move_action() -> Dict[str, object]:
+    return {"type": "move", "x": random.uniform(-1, 1), "z": random.uniform(-1, 1)}
+
+
+def look_action() -> Dict[str, object]:
+    return {
+        "type": "look",
+        "movementX": random.randint(-15, 15),
+        "movementY": random.randint(-15, 15),
+    }
+
+
+def click_action() -> Dict[str, object]:
+    return {"type": "documentMouseEvent", "button": 0, "action": random.choice(["down", "up"])}
+
+
+def hotbar_action() -> Dict[str, object]:
+    return {"type": "setHotbarSlot", "slot": random.randint(0, 8)}
+
+
+def jump_action() -> Dict[str, object]:
+    return {"type": "jump"}
+
+
+ACTIONS: list[ActionGenerator] = [
+    move_action,
+    look_action,
+    click_action,
+    hotbar_action,
+    jump_action,
+]
+
+
+async def stress_test(uri: str, duration: float = 60.0, interval: float = 0.1) -> None:
+    """Run stress test for ``duration`` seconds."""
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"init": "pygame"}))
+        end = time.time() + duration
+        while time.time() < end:
+            action = random.choice(ACTIONS)()
+            await ws.send(json.dumps(action))
+            await asyncio.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send random actions to WebSocket server for stress testing")
+    parser.add_argument("--uri", default="ws://localhost:8081", help="WebSocket server URI")
+    parser.add_argument("--duration", type=float, default=60.0, help="Duration of the test in seconds")
+    parser.add_argument("--interval", type=float, default=0.1, help="Delay between actions in seconds")
+    args = parser.parse_args()
+    asyncio.run(stress_test(args.uri, args.duration, args.interval))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `performance_monitor.py` for collecting CPU and memory stats
- add `stress_test_runner.py` to send randomized actions to the WebSocket server

## Testing
- `pip install -r requirements_pygame.txt`
- `pip install python-dotenv`
- `pytest -q` *(fails: ModuleNotFoundError for ws_client and async_mcp_executor)*

------
https://chatgpt.com/codex/tasks/task_e_6845af4a15b883258fcbabf4037101ac