### PR TITLE
Add additional consistency tests and simulation

### DIFF
--- a/docs/getbotstatus_consistency.md
+++ b/docs/getbotstatus_consistency.md
@@ -1,0 +1,23 @@
+# getBotStatus Consistency Tests
+
+The repository currently includes unit tests for Agent 3's parsing utilities. This note explains whether those tests confirm the historical consistency issues with `getBotStatus`.
+
+## What the existing tests check
+
+- **Parser correctness**: `test_parse_bot_status_basic` feeds a sample status string to `parse_bot_status()` and verifies that position, rotation, biome, inventory and looking-at data are extracted correctly.
+- **State stability helper**: `test_wait_for_state_stable` uses a dummy async getter that always returns the same text. The helper waits until the same parsed status is observed multiple times.
+
+These tests ensure the parser works and that the stability helper returns when identical text is repeated. They do **not** involve a running game instance or the real `getBotStatus` command. As such they cannot reveal whether `getBotStatus` sometimes reports inconsistent values in practice.
+
+## Why the consistency problem remains unconfirmed
+
+The historical "consistency problem" refers to `getBotStatus` occasionally reporting different positions or rotations for the same game state due to async timing issues. Because our tests rely on a static string and a dummy provider, they don't exercise the real data path where that inconsistency was observed. Therefore the tests neither confirm nor disprove the problem—they merely verify that our parsing logic would notice if the same text repeats.
+
+## Ideas for tests that would confirm/disprove it
+
+1. **Live server integration**: Spin up a headless Minecraft instance (or use mineflayer) and repeatedly call `getBotStatus` while the bot is idle. Expect three identical results in a row.
+2. **Action sequences**: Issue known movement or rotation commands, then call `wait_for_state_stable()` and verify the final position/rotation matches what the commands should produce. Repeat to ensure results are consistent across runs.
+3. **Edge cases**: Test near world boundaries and with yaw wrapping (e.g., rotating past 359°) to see if values jitter.
+4. **Statistical analysis**: Collect many sequences and compute variance in reported positions/rotations. Any non-zero variance when repeating the same commands would indicate inconsistency.
+
+Implementing these integration tests would require a running game environment and more complex orchestration, but they would directly address whether the consistency problem still exists.

--- a/docs/getbotstatus_consistency_additional_round.md
+++ b/docs/getbotstatus_consistency_additional_round.md
@@ -1,0 +1,30 @@
+# getBotStatus Consistency - Additional Round of Tests
+
+This update introduces two more parser cases and two WebSocket tests. A new script
+`ws_cross_mode_consistency_extended.py` demonstrates how multiple MCP clients
+and reconnecting bots communicate through the `CrossModeServer`.
+
+## What the new tests cover
+
+- **Multiple `Day` lines**: `test_parse_bot_status_multiple_day_lines` confirms
+  that the parser keeps the last day/time line when several appear.
+- **Trailing whitespace**: `test_parse_bot_status_trailing_whitespace` verifies
+  that extra spaces at the ends of lines do not break parsing.
+- **Multiple MCP clients**: `test_cross_mode_multiple_mcp_clients` checks that
+  acknowledgements from bots are broadcast to every MCP connection.
+- **Bot reconnect**: `test_cross_mode_reconnect_bot` ensures a bot can
+  disconnect and reconnect while the server properly forwards subsequent
+  commands.
+
+These additions expand coverage but still use static strings and a minimal
+WebSocket simulation. They show the parser and forwarding logic behave as
+expected, yet they cannot reveal whether real `getBotStatus` output is always
+consistent.
+
+## Future testing needed
+
+To conclusively confirm or disprove the historical inconsistency issue we would
+need integration tests running against a live game instance. Those tests should
+collect repeated `getBotStatus` samples while issuing commands and compare the
+results for variance.
+

--- a/docs/getbotstatus_consistency_cross_mode.md
+++ b/docs/getbotstatus_consistency_cross_mode.md
@@ -1,0 +1,34 @@
+# getBotStatus Consistency - Cross Mode Simulation
+
+This round introduces a small WebSocket simulation and two extra unit tests for
+Agent 3's parser utilities.
+
+## What the new tests cover
+
+- **Multiple biome lines**: `test_parse_bot_status_multiple_biomes` ensures that
+  when several `Biome:` lines are present, the parser keeps the last one.
+- **Exception propagation**: `test_wait_for_state_stable_propagates_exception`
+  confirms that errors from the status provider bubble up rather than being
+  swallowed.
+- **Cross mode forwarding**: `test_cross_mode_message_flow` spins up a minimal
+  server with bot, MCP and pygame clients. It verifies that commands from both
+  MCP and pygame reach the bot and that bot replies are forwarded only to MCP
+  clients.
+
+## Do these tests confirm the consistency issue?
+
+No. They still operate in a synthetic environment with canned strings and a tiny
+WebSocket simulation. They show that the parser behaves predictably for some
+additional cases and that our server-style forwarding logic is sound, but they
+do not use a real Minecraft instance. Therefore they neither confirm nor
+conclusively disprove the historical `getBotStatus` inconsistency.
+
+## What tests would provide a definitive answer?
+
+To really check cross mode consistency we would need integration tests that
+start a full server, connect all three client types and drive actual gameplay.
+By issuing identical commands through MCP and pygame modes while monitoring the
+bot's position/rotation via `getBotStatus`, we could detect any divergence. Such
+an environment is beyond these unit tests but would finally settle whether the
+inconsistency still exists.
+

--- a/docs/getbotstatus_consistency_extra_tests.md
+++ b/docs/getbotstatus_consistency_extra_tests.md
@@ -1,0 +1,32 @@
+# getBotStatus Consistency - Extra Tests
+
+The latest test suite introduces a few more edge cases for the parser and the
+state stability helper.
+
+## What the extra tests cover
+
+- **Missing position line**: `test_parse_bot_status_missing_position` verifies
+  that when no `Position:` line is present, the parser returns default
+  coordinates `(0, 0, 0)` and leaves rotation blank.
+- **Line order flexibility**: `test_parse_bot_status_line_order` confirms that
+  lines can appear in any order and still parse correctly.
+- **Multi-line hotbar items**: `test_parse_bot_status_multiline_hotbar` checks
+  that hotbar entries are detected even when split across lines.
+
+Together with the previous suites, these tests show that the parser handles
+various textual quirks and that `wait_for_state_stable` can cope with immediate
+and delayed stability.
+
+## Do these tests confirm the consistency problem?
+
+No. They continue to operate on static strings and dummy async providers. They
+demonstrate parser robustness but do not interact with a real `getBotStatus`
+command. Therefore they neither confirm nor disprove the historic inconsistency
+issue.
+
+## Tests needed for real confirmation
+
+To actually verify consistency we would need integration tests that repeatedly
+call `getBotStatus` in a live game environment, comparing consecutive results and
+checking commanded movements against reported positions and rotations. Such tests
+would reveal whether the output ever jitters or diverges from expected values.

--- a/docs/getbotstatus_consistency_final_round.md
+++ b/docs/getbotstatus_consistency_final_round.md
@@ -1,0 +1,43 @@
+# getBotStatus Consistency - Final Round of Tests
+
+The newest suite introduces a few more edge cases and a callback check for the test
+WebSocket client.
+
+## What these tests cover
+
+- **Duplicate position lines**: `test_parse_bot_status_duplicate_position` ensures
+  the parser uses the last `Position:` line when multiple are present.
+- **CRLF newline handling**: `test_parse_bot_status_crlf_newlines` verifies Windows
+  style line endings do not break parsing.
+- **Unknown lines ignored**: `test_parse_bot_status_unknown_lines` confirms extra
+  unrecognised lines are safely skipped.
+- **Delayed stability**: `test_wait_for_state_stable_delayed` feeds three different
+  status texts before repeating one to check that the stability helper resets its
+  counter correctly.
+- **WebSocket callbacks**: `test_connect_callbacks` makes sure the lightweight
+  `WebSocketClient` triggers its connect and disconnect callbacks.
+
+## Do these tests confirm the consistency problem?
+
+No. Like the previous rounds, they rely on static strings and a dummy websocket.
+They show that our parser and helper functions behave predictably for various
+synthetic scenarios, but they still do not exercise the real `getBotStatus`
+command in a live Minecraft world.
+
+## Tests needed for a real answer
+
+To truly confirm or disprove the historic inconsistency we would need integration
+experiments that:
+
+1. Collect consecutive `getBotStatus` samples from an actual server to look for
+   jitter while the bot is idle.
+2. Issue movement or rotation commands and verify the reported state after waiting
+   for stability matches the expected outcome.
+3. Run these sequences near world edges and with rotations that wrap around to
+   check for boundary bugs.
+4. Gather statistics across many runs and fail if the variance exceeds a tight
+   tolerance.
+
+Until such integration tests exist, unit tests can only confirm that our parsing
+code would notice inconsistent output—they cannot prove whether it actually
+occurs.

--- a/docs/getbotstatus_consistency_followup.md
+++ b/docs/getbotstatus_consistency_followup.md
@@ -1,0 +1,13 @@
+# getBotStatus Consistency Follow-up
+
+The new tests extend coverage for Agent 3's parsing utilities. They check missing-field handling, rotation wraparound, multiple hotbar items, and timeout behavior of `wait_for_state_stable()`.
+
+These tests confirm the parser's robustness for edge cases and ensure the stability helper raises `TimeoutError` when output keeps changing. However, they still operate on static text and do not run against a real Minecraft instance. As such, they neither confirm nor disprove historical inconsistencies observed with live `getBotStatus` calls.
+
+## Next Steps for Real Confirmation
+
+- **Integration environment**: Run the bot in a controlled world and call `getBotStatus` repeatedly while idle to verify identical outputs.
+- **Command sequences**: Execute movement or rotation actions, wait for stability, and compare reported state to expected results.
+- **Stress scenarios**: Test near boundaries and with extreme rotations to search for jitter.
+
+Only with such integration tests can we truly confirm whether the consistency issues persist.

--- a/docs/getbotstatus_consistency_latest.md
+++ b/docs/getbotstatus_consistency_latest.md
@@ -1,0 +1,26 @@
+# getBotStatus Consistency - Latest Tests
+
+This note describes the newest unit tests for Agent 3's parser and explains how they relate to the historic consistency issue.
+
+## What the latest tests cover
+
+- **Negative rotation values**: `test_parse_bot_status_negative_rotation` ensures yaw and pitch below ±360° parse correctly and that the `looking_at` field captures additional text.
+- **Empty hotbar line**: `test_parse_bot_status_no_hotbar_items` verifies that the parser gracefully handles a `Hotbar:` line with no items and leaves `selected_slot` unset.
+- **Immediate stability detection**: `test_wait_for_state_stable_immediate` confirms that the stability helper returns after a single call when `attempts=1`.
+
+These extend previous edge case coverage (precision, wraparound, state recovery, timeout) and help prove that the parser and stability helper behave predictably when fed representative strings.
+
+## Do these tests confirm the consistency problem?
+
+No. Like earlier suites, they operate purely on canned text and do not interact with a live Minecraft instance. They show that our parsing code would correctly recognise stable output, but they don't test whether `getBotStatus` itself ever produces inconsistent data during real gameplay.
+
+## What tests would provide a definitive answer?
+
+To truly confirm or disprove the historic inconsistency issue we would need integration tests that:
+
+1. **Collect live samples** of consecutive `getBotStatus` calls while the bot is idle to look for jitter.
+2. **Drive actions** (movement or rotation commands), wait for stability and compare the final state to expected outcomes.
+3. **Probe boundary scenarios** such as world edges or rotations beyond 360° to detect wraparound bugs.
+4. **Measure variance** across many runs and fail if observed spread exceeds a tight tolerance.
+
+Implementing such tests requires a running server environment and orchestration code, but only they can resolve the open question about real-world consistency.

--- a/docs/getbotstatus_consistency_new_tests.md
+++ b/docs/getbotstatus_consistency_new_tests.md
@@ -1,0 +1,25 @@
+# getBotStatus Consistency - Additional Tests
+
+This note documents the latest unit tests added for Agent 3's parsing utilities and explains their relevance to the historic consistency issue.
+
+## What the new tests cover
+
+- **Precision handling**: `test_parse_bot_status_precision` validates that coordinates and rotation angles with many decimal places parse correctly and that hotbar items beyond slot 0 and 1 are captured.
+- **Stability recovery**: `test_wait_for_state_stable_recovers` feeds changing output until a repeated value appears, verifying that `wait_for_state_stable` resets its counter on changes and eventually returns when the text stabilizes.
+
+Together with earlier tests (missing fields, wraparound, multiple items, timeout), these ensure the parser and stability helper behave robustly for static input.
+
+## Do these tests confirm the consistency problem?
+
+No. Like the previous suites, they rely on canned strings and do not interact with a real Minecraft instance. They prove only that our parsing code can detect identical results and handle edge cases. They cannot demonstrate whether `getBotStatus` itself ever reports inconsistent data while the game is running.
+
+## Tests needed for a real answer
+
+To actually confirm or disprove the historic inconsistency issue, we would need integration tests that:
+
+1. **Collect live samples**: Continuously call `getBotStatus` from a running server while the bot is idle and check for jitter in successive outputs.
+2. **Command-driven checks**: Issue movement or rotation commands, wait for stability, and assert that the reported state matches the expected result every time.
+3. **Boundary scenarios**: Run these tests near world edges and with rotations that wrap past ±360° to detect any irregularities.
+4. **Statistical evaluation**: Gather many sequences, compute variance, and fail if the spread exceeds a small tolerance.
+
+Only such integration-level testing would definitively reveal whether the consistency problem still exists.

--- a/docs/getbotstatus_consistency_simulation.md
+++ b/docs/getbotstatus_consistency_simulation.md
@@ -1,0 +1,20 @@
+# getBotStatus Consistency - Simulation Update
+
+The latest round extends the test suite and adds a small script to simulate WebSocket traffic across bot, MCP and pygame clients. These additions continue to exercise the parser and forwarding logic but still operate entirely on synthetic data.
+
+## New tests
+
+- **Extra spacing**: `test_parse_bot_status_extra_spaces` ensures the parser tolerates irregular whitespace around the position and hotbar fields.
+- **Multiple bots**: `test_cross_mode_multiple_bots` verifies that a command from a single MCP client reaches all connected bot clients and that acknowledgements from each bot return to the MCP.
+- **Client reconnects**: `test_cross_mode_reconnect_client` confirms the server cleans up disconnected clients so a new MCP connection still receives replies.
+
+These tests confirm our utilities behave predictably in controlled scenarios. They do not interact with a live Minecraft instance, so they cannot prove whether `getBotStatus` ever produces inconsistent data during real gameplay.
+
+## Simulation code
+
+`ws_cross_mode_consistency.py` starts the `CrossModeServer` and spawns bot, MCP and pygame clients that exchange a few messages. This demonstrates the message flow needed to check cross mode behaviour.
+
+## Still unresolved
+
+Because the tests rely on canned strings and a minimal server, they do not reveal whether `getBotStatus` occasionally reports mismatched positions or rotations. To fully confirm or disprove that historical issue we would need integration tests that drive the game, issue real commands and compare reported state over time.
+

--- a/getbotstatus_parser.py
+++ b/getbotstatus_parser.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import re
+import asyncio
+from dataclasses import dataclass, field
+from typing import List, Optional, Callable, Awaitable
+
+
+@dataclass(eq=True, frozen=True)
+class Position:
+    x: float
+    y: float
+    z: float
+
+
+@dataclass(eq=True, frozen=True)
+class Rotation:
+    yaw: float
+    pitch: float
+    cardinal_direction: str
+
+
+@dataclass(eq=True, frozen=True)
+class HotbarItem:
+    slot: int
+    name: str
+    count: int
+
+
+@dataclass(eq=True, frozen=True)
+class BotStatus:
+    position: Position
+    rotation: Rotation
+    biome: Optional[str] = None
+    day: Optional[int] = None
+    minutes_until_event: Optional[float] = None
+    next_event: Optional[str] = None
+    selected_slot: Optional[int] = None
+    hotbar: List[HotbarItem] = field(default_factory=list)
+    looking_at: Optional[str] = None
+
+
+POSITION_RE = re.compile(r"Position:\s*\(([-\d\.]+),\s*([-\d\.]+),\s*([-\d\.]+)\)\s*facing\s+([A-Za-z]+)\s*\(([-\d\.]+)°,\s*([-\d\.]+)°\)")
+BIOME_RE = re.compile(r"Biome:\s*(.+)")
+DAY_RE = re.compile(r"Day\s+(\d+),\s*([\d\.]+)\s*minutes\s*until\s*(\w+)")
+SLOT_RE = re.compile(r"Selected slot:\s*(\d+)")
+HOTBAR_ITEM_RE = re.compile(r"\[(\d+):\s*([^\]]+)\sx(\d+)\]")
+LOOKING_RE = re.compile(r"Looking at:\s*(.+)")
+
+
+def parse_bot_status(text: str) -> BotStatus:
+    lines = [line.strip() for line in text.strip().splitlines() if line.strip() and not line.startswith("====")]
+    position = Position(0.0, 0.0, 0.0)
+    rotation = Rotation(0.0, 0.0, "")
+    biome = None
+    day = None
+    minutes_until_event = None
+    next_event = None
+    selected_slot = None
+    hotbar: List[HotbarItem] = []
+    looking_at = None
+
+    for line in lines:
+        if m := POSITION_RE.search(line):
+            position = Position(float(m.group(1)), float(m.group(2)), float(m.group(3)))
+            rotation = Rotation(float(m.group(5)), float(m.group(6)), m.group(4))
+        elif m := BIOME_RE.search(line):
+            biome = m.group(1)
+        elif m := DAY_RE.search(line):
+            day = int(m.group(1))
+            minutes_until_event = float(m.group(2))
+            next_event = m.group(3)
+        elif m := SLOT_RE.search(line):
+            selected_slot = int(m.group(1))
+        elif m := HOTBAR_ITEM_RE.search(line):
+            for match in HOTBAR_ITEM_RE.finditer(line):
+                hotbar.append(
+                    HotbarItem(int(match.group(1)), match.group(2), int(match.group(3)))
+                )
+        elif m := LOOKING_RE.search(line):
+            looking_at = m.group(1)
+
+    return BotStatus(
+        position=position,
+        rotation=rotation,
+        biome=biome,
+        day=day,
+        minutes_until_event=minutes_until_event,
+        next_event=next_event,
+        selected_slot=selected_slot,
+        hotbar=hotbar,
+        looking_at=looking_at,
+    )
+
+
+async def wait_for_state_stable(
+    get_status: Callable[[], Awaitable[str]],
+    *,
+    attempts: int = 3,
+    interval: float = 0.1,
+    timeout: float = 5.0,
+) -> BotStatus:
+    """Wait until get_status returns identical BotStatus for `attempts` times."""
+
+    last_status: Optional[BotStatus] = None
+    stable_count = 0
+    start = asyncio.get_event_loop().time()
+
+    while True:
+        text = await get_status()
+        status = parse_bot_status(text)
+        if status == last_status:
+            stable_count += 1
+            if stable_count >= attempts:
+                return status
+        else:
+            stable_count = 1
+            last_status = status
+
+        if asyncio.get_event_loop().time() - start > timeout:
+            raise TimeoutError("State did not stabilize within timeout")
+
+        await asyncio.sleep(interval)
+

--- a/tests/test_getbotstatus_parser.py
+++ b/tests/test_getbotstatus_parser.py
@@ -1,0 +1,323 @@
+import asyncio
+import pytest
+
+from getbotstatus_parser import (
+    parse_bot_status,
+    wait_for_state_stable,
+    Position,
+    Rotation,
+    HotbarItem,
+)
+
+SAMPLE_STATUS = """====
+Position: (30, 63, -18) facing East (-288.15°, -2.55°)
+Biome: Sparse Jungle
+Day 0, 8.71 minutes until sunset
+Selected slot: 1
+Hotbar: [0: Oak Sapling x3] [1: Jungle Log x1]
+Looking at: Vines (is close enough to dig)
+===="""
+
+
+def test_parse_bot_status_basic():
+    status = parse_bot_status(SAMPLE_STATUS)
+    assert status.position == Position(30.0, 63.0, -18.0)
+    assert status.rotation == Rotation(-288.15, -2.55, "East")
+    assert status.biome == "Sparse Jungle"
+    assert status.day == 0
+    assert status.minutes_until_event == 8.71
+    assert status.next_event == "sunset"
+    assert status.selected_slot == 1
+    assert status.hotbar == [
+        HotbarItem(0, "Oak Sapling", 3),
+        HotbarItem(1, "Jungle Log", 1),
+    ]
+    assert status.looking_at.startswith("Vines")
+
+
+class Dummy:
+    def __init__(self):
+        self.calls = 0
+
+    async def get(self) -> str:
+        self.calls += 1
+        # first call returns same text, second call also same -> stable after two calls
+        return SAMPLE_STATUS
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable():
+    dummy = Dummy()
+    status = await wait_for_state_stable(dummy.get, attempts=2, interval=0.01, timeout=1)
+    assert status.position.x == 30.0
+    assert dummy.calls >= 2
+
+
+MISSING_STATUS = """====
+Position: (10, 64, 20) facing South (180°, 0°)
+===="""
+
+WRAP_STATUS = """====
+Position: (0, 64, 0) facing North (361°, -1°)
+Hotbar: [0: Dirt x64] [1: Stone x64] [2: Stick x10]
+===="""
+
+class Flapping:
+    def __init__(self):
+        self.state = False
+
+    async def get(self) -> str:
+        self.state = not self.state
+        if self.state:
+            return SAMPLE_STATUS
+        return SAMPLE_STATUS.replace("East", "West")
+
+
+def test_parse_bot_status_missing_fields():
+    status = parse_bot_status(MISSING_STATUS)
+    assert status.position == Position(10.0, 64.0, 20.0)
+    assert status.rotation == Rotation(180.0, 0.0, "South")
+    assert status.biome is None
+    assert status.hotbar == []
+    assert status.looking_at is None
+
+
+def test_parse_bot_status_wraparound():
+    status = parse_bot_status(WRAP_STATUS)
+    assert status.rotation.yaw == 361.0
+    assert len(status.hotbar) == 3
+    assert status.hotbar[0] == HotbarItem(0, "Dirt", 64)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable_timeout():
+    flapping = Flapping()
+    with pytest.raises(TimeoutError):
+        await wait_for_state_stable(flapping.get, attempts=3, interval=0.01, timeout=0.2)
+PRECISION_STATUS = """====
+Position: (-1024.125, 64.5, 2048.875) facing West (270.123°, -45.987°)
+Biome: Plains
+Day 1, 12.5 minutes until sunrise
+Selected slot: 2
+Hotbar: [0: Torch x64] [2: Diamond Pickaxe x1]
+===="""
+
+class Oscillating:
+    def __init__(self):
+        self.count = 0
+
+    async def get(self) -> str:
+        self.count += 1
+        if self.count == 1:
+            return SAMPLE_STATUS.replace("Jungle Log", "Oak Log")
+        return SAMPLE_STATUS
+
+
+def test_parse_bot_status_precision():
+    status = parse_bot_status(PRECISION_STATUS)
+    assert status.position == Position(-1024.125, 64.5, 2048.875)
+    assert status.rotation == Rotation(270.123, -45.987, "West")
+    assert status.hotbar[-1] == HotbarItem(2, "Diamond Pickaxe", 1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable_recovers():
+    osc = Oscillating()
+    status = await wait_for_state_stable(osc.get, attempts=2, interval=0.01, timeout=1)
+    assert status.hotbar[1].name == "Jungle Log"
+    assert osc.count >= 3
+
+# Additional edge case samples
+NEGATIVE_ROT_STATUS = """====
+Position: (0, 64, 0) facing West (-450°, 10°)
+Hotbar: [0: Dirt x1]
+Looking at: Stone (cannot dig - too far away)
+===="""
+
+NO_HOTBAR_STATUS = """====
+Position: (5, 65, -5) facing North (0°, 0°)
+Hotbar:
+===="""
+
+
+def test_parse_bot_status_negative_rotation():
+    status = parse_bot_status(NEGATIVE_ROT_STATUS)
+    assert status.rotation.yaw == -450.0
+    assert status.rotation.pitch == 10.0
+    assert status.looking_at.startswith("Stone")
+
+
+def test_parse_bot_status_no_hotbar_items():
+    status = parse_bot_status(NO_HOTBAR_STATUS)
+    assert status.hotbar == []
+    assert status.selected_slot is None
+
+
+class Immediate:
+    async def get(self) -> str:
+        return SAMPLE_STATUS
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable_immediate():
+    immediate = Immediate()
+    status = await wait_for_state_stable(immediate.get, attempts=1, interval=0.01, timeout=0.5)
+    assert status.rotation.cardinal_direction == "East"
+
+
+# Additional edge cases
+MISSING_POSITION_STATUS = """====
+Biome: Forest
+Day 3, 1.5 minutes until sunrise
+Selected slot: 0
+Hotbar: [0: Dirt x1]
+===="""
+
+LINE_ORDER_STATUS = """====
+Hotbar: [0: Dirt x64] [1: Stone x64]
+Looking at: Grass Block (is too far away)
+Day 2, 5.0 minutes until sunrise
+Position: (1, 2, 3) facing North (0°, 0°)
+Biome: Plains
+Selected slot: 1
+===="""
+
+MULTILINE_HOTBAR_STATUS = """====
+Position: (0, 64, 0) facing South (90°, 0°)
+Hotbar: [0: Stone x64]
+[1: Stick x1]
+===="""
+
+
+def test_parse_bot_status_missing_position():
+    status = parse_bot_status(MISSING_POSITION_STATUS)
+    assert status.position == Position(0.0, 0.0, 0.0)
+    assert status.rotation == Rotation(0.0, 0.0, "")
+    assert status.biome == "Forest"
+    assert status.hotbar == [HotbarItem(0, "Dirt", 1)]
+
+
+def test_parse_bot_status_line_order():
+    status = parse_bot_status(LINE_ORDER_STATUS)
+    assert status.position == Position(1.0, 2.0, 3.0)
+    assert status.hotbar[0].name == "Dirt"
+    assert status.looking_at.startswith("Grass Block")
+
+
+def test_parse_bot_status_multiline_hotbar():
+    status = parse_bot_status(MULTILINE_HOTBAR_STATUS)
+    assert len(status.hotbar) == 2
+    assert status.hotbar[1] == HotbarItem(1, "Stick", 1)
+
+# New edge case samples
+DUPLICATE_POSITION_STATUS = """====
+Position: (0, 0, 0) facing North (0°, 0°)
+Biome: Plains
+Position: (1, 2, 3) facing South (180°, 0°)
+Hotbar: [0: Dirt x64]
+===="""
+
+CRLF_STATUS = "====\r\nPosition: (2, 3, 4) facing East (90°, 0°)\r\nBiome: Desert\r\n====\r\n"
+
+UNKNOWN_LINE_STATUS = """====
+Foo: bar
+Position: (5, 5, 5) facing West (270°, 0°)
+Baz: qux
+===="""
+
+class GradualStable:
+    def __init__(self):
+        self.calls = 0
+
+    async def get(self) -> str:
+        self.calls += 1
+        if self.calls <= 3:
+            return SAMPLE_STATUS.replace("East", f"East-{self.calls}")
+        return SAMPLE_STATUS
+
+
+def test_parse_bot_status_duplicate_position():
+    status = parse_bot_status(DUPLICATE_POSITION_STATUS)
+    assert status.position == Position(1.0, 2.0, 3.0)
+    assert status.rotation.cardinal_direction == "South"
+
+
+def test_parse_bot_status_crlf_newlines():
+    status = parse_bot_status(CRLF_STATUS)
+    assert status.position == Position(2.0, 3.0, 4.0)
+    assert status.biome == "Desert"
+
+
+def test_parse_bot_status_unknown_lines():
+    status = parse_bot_status(UNKNOWN_LINE_STATUS)
+    assert status.position == Position(5.0, 5.0, 5.0)
+    assert status.rotation.cardinal_direction == "West"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable_delayed():
+    stable = GradualStable()
+    status = await wait_for_state_stable(stable.get, attempts=2, interval=0.01, timeout=1)
+    assert status.rotation.cardinal_direction == "East"
+    assert stable.calls >= 4
+
+MULTI_BIOME_STATUS = """====
+Biome: Plains
+Biome: Desert
+Position: (2, 65, 2) facing East (90°, 0°)
+===="""
+
+class ExplodingProvider:
+    def __init__(self):
+        self.called = False
+    async def get(self) -> str:
+        if not self.called:
+            self.called = True
+            return SAMPLE_STATUS
+        raise RuntimeError("boom")
+
+
+def test_parse_bot_status_multiple_biomes():
+    status = parse_bot_status(MULTI_BIOME_STATUS)
+    assert status.biome == "Desert"
+    assert status.position == Position(2.0, 65.0, 2.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_state_stable_propagates_exception():
+    provider = ExplodingProvider()
+    with pytest.raises(RuntimeError):
+        await wait_for_state_stable(provider.get, attempts=2, interval=0.01, timeout=1)
+
+SPACED_STATUS = """====
+Position:    (1, 2, 3)     facing   North   (0°, 0°)
+Hotbar:    [0: Dirt x1]    [1: Stone x2]
+===="""
+
+def test_parse_bot_status_extra_spaces():
+    status = parse_bot_status(SPACED_STATUS)
+    assert status.position == Position(1.0, 2.0, 3.0)
+    assert status.rotation.cardinal_direction == "North"
+    assert status.hotbar[1] == HotbarItem(1, "Stone", 2)
+
+MULTI_DAY_STATUS = """====
+Day 1, 10.0 minutes until sunrise
+Day 2, 5.0 minutes until sunset
+Position: (1, 64, 1) facing North (0°, 0°)
+===="""
+
+TRAILING_WS_STATUS = "====\nPosition: (2, 65, 2) facing West (270°, 0°)   \nBiome: Desert   \n====   "
+
+
+def test_parse_bot_status_multiple_day_lines():
+    status = parse_bot_status(MULTI_DAY_STATUS)
+    assert status.day == 2
+    assert status.minutes_until_event == 5.0
+    assert status.next_event == "sunset"
+
+
+def test_parse_bot_status_trailing_whitespace():
+    status = parse_bot_status(TRAILING_WS_STATUS)
+    assert status.position == Position(2.0, 65.0, 2.0)
+    assert status.biome == "Desert"
+

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -30,3 +30,24 @@ async def test_basic_send(tmp_path):
     await done.wait()
     server.close()
     await server.wait_closed()
+
+@pytest.mark.asyncio
+async def test_connect_callbacks(tmp_path):
+    server = await websockets.serve(echo, "localhost", 8766)
+    connected = asyncio.Event()
+    disconnected = asyncio.Event()
+
+    def on_connect():
+        connected.set()
+
+    def on_disconnect():
+        disconnected.set()
+
+    client = WebSocketClient("ws://localhost:8766", on_connect=on_connect, on_disconnect=on_disconnect)
+    client.start()
+    await asyncio.wait_for(connected.wait(), timeout=1)
+    await asyncio.sleep(0.1)
+    await client.stop()
+    await asyncio.wait_for(disconnected.wait(), timeout=1)
+    server.close()
+    await server.wait_closed()

--- a/tests/test_ws_cross_mode.py
+++ b/tests/test_ws_cross_mode.py
@@ -1,0 +1,157 @@
+import asyncio
+import json
+import websockets
+import pytest
+
+from ws_cross_mode_sim import CrossModeServer
+
+@pytest.mark.asyncio
+async def test_cross_mode_message_flow():
+    server = CrossModeServer(port=8768)
+    await server.start()
+
+    bot_received = []
+    mcp_received = []
+
+    async def bot():
+        async with websockets.connect("ws://localhost:8768") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            # Expect command from mcp then pygame
+            for _ in range(2):
+                msg = json.loads(await ws.recv())
+                bot_received.append(msg)
+                await ws.send(json.dumps({"ack": msg.get("cmd")}))
+
+    async def mcp():
+        async with websockets.connect("ws://localhost:8768") as ws:
+            await ws.send(json.dumps({"init": "mcp"}))
+            await ws.send(json.dumps({"cmd": "from_mcp"}))
+            mcp_received.append(json.loads(await ws.recv()))
+            mcp_received.append(json.loads(await ws.recv()))
+
+    async def pygame():
+        async with websockets.connect("ws://localhost:8768") as ws:
+            await ws.send(json.dumps({"init": "pygame"}))
+            await ws.send(json.dumps({"cmd": "from_pygame"}))
+            await asyncio.sleep(0.1)
+
+    await asyncio.gather(bot(), mcp(), pygame())
+    await server.stop()
+
+    assert bot_received == [{"cmd": "from_mcp"}, {"cmd": "from_pygame"}]
+    assert mcp_received == [{"ack": "from_mcp"}, {"ack": "from_pygame"}]
+
+
+@pytest.mark.asyncio
+async def test_cross_mode_multiple_bots():
+    server = CrossModeServer(port=8769)
+    await server.start()
+
+    async def bot(name):
+        async with websockets.connect("ws://localhost:8769") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            msg = json.loads(await ws.recv())
+            await ws.send(json.dumps({"ack": f"{name}:{msg.get('cmd')}"}))
+
+    async def mcp():
+        async with websockets.connect("ws://localhost:8769") as ws:
+            await ws.send(json.dumps({"init": "mcp"}))
+            await ws.send(json.dumps({"cmd": "test"}))
+            acks = [json.loads(await ws.recv()), json.loads(await ws.recv())]
+            return acks
+
+    results = await asyncio.gather(bot("b1"), bot("b2"), mcp())
+    await server.stop()
+
+    acks = results[-1]
+    assert {ack["ack"] for ack in acks} == {"b1:test", "b2:test"}
+
+@pytest.mark.asyncio
+async def test_cross_mode_reconnect_client():
+    server = CrossModeServer(port=8770)
+    await server.start()
+    results = []
+
+    async def bot():
+        async with websockets.connect("ws://localhost:8770") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            for _ in range(2):
+                msg = json.loads(await ws.recv())
+                await ws.send(json.dumps({"ack": msg["cmd"]}))
+
+    async def mcp():
+        async with websockets.connect("ws://localhost:8770") as ws:
+            await ws.send(json.dumps({"init": "mcp"}))
+            await ws.send(json.dumps({"cmd": "one"}))
+            await ws.recv()
+        await asyncio.sleep(0.05)
+        async with websockets.connect("ws://localhost:8770") as ws2:
+            await ws2.send(json.dumps({"init": "mcp"}))
+            await ws2.send(json.dumps({"cmd": "two"}))
+            results.append(json.loads(await ws2.recv()))
+
+    await asyncio.gather(bot(), mcp())
+    await server.stop()
+    assert results == [{"ack": "two"}]
+
+
+@pytest.mark.asyncio
+async def test_cross_mode_multiple_mcp_clients():
+    server = CrossModeServer(port=8771)
+    await server.start()
+    results = []
+
+    async def bot():
+        async with websockets.connect("ws://localhost:8771") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            for _ in range(2):
+                msg = json.loads(await ws.recv())
+                await ws.send(json.dumps({"ack": msg["cmd"]}))
+
+    async def mcp(name):
+        async with websockets.connect("ws://localhost:8771") as ws:
+            await ws.send(json.dumps({"init": "mcp"}))
+            await ws.send(json.dumps({"cmd": name}))
+            a1 = json.loads(await ws.recv())
+            a2 = json.loads(await ws.recv())
+            results.append({"name": name, "acks": {a1["ack"], a2["ack"]}})
+
+    await asyncio.gather(bot(), mcp("a"), mcp("b"))
+    await server.stop()
+
+    assert {"a", "b"} == results[0]["acks"]
+    assert {"a", "b"} == results[1]["acks"]
+
+@pytest.mark.asyncio
+async def test_cross_mode_reconnect_bot():
+    server = CrossModeServer(port=8772)
+    await server.start()
+    results = []
+    first_done = asyncio.Event()
+
+    async def bot_first():
+        async with websockets.connect("ws://localhost:8772") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            msg = json.loads(await ws.recv())
+            await ws.send(json.dumps({"ack": f"first:{msg['cmd']}"}))
+        first_done.set()
+
+    async def bot_second():
+        async with websockets.connect("ws://localhost:8772") as ws:
+            await ws.send(json.dumps({"init": "bot"}))
+            msg = json.loads(await ws.recv())
+            await ws.send(json.dumps({"ack": f"second:{msg['cmd']}"}))
+
+    async def mcp():
+        async with websockets.connect("ws://localhost:8772") as ws:
+            await ws.send(json.dumps({"init": "mcp"}))
+            await ws.send(json.dumps({"cmd": "one"}))
+            results.append(json.loads(await ws.recv()))
+            await first_done.wait()
+            await ws.send(json.dumps({"cmd": "two"}))
+            results.append(json.loads(await ws.recv()))
+
+    await asyncio.gather(bot_first(), mcp(), bot_second())
+    await server.stop()
+    assert results == [{"ack": "first:one"}, {"ack": "second:two"}]
+

--- a/ws_client.py
+++ b/ws_client.py
@@ -1,0 +1,39 @@
+import asyncio
+import json
+import threading
+import websockets
+
+
+class WebSocketClient:
+    """Minimal async WebSocket client used for tests."""
+
+    def __init__(self, url: str, on_connect=None, on_disconnect=None) -> None:
+        self.url = url
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self.ws = None
+
+    def start(self) -> None:
+        self.thread.start()
+        asyncio.run_coroutine_threadsafe(self._connect(), self.loop)
+
+    async def _connect(self) -> None:
+        self.ws = await websockets.connect(self.url)
+        if self.on_connect:
+            self.on_connect()
+
+    def send(self, data) -> None:
+        if not self.ws:
+            raise RuntimeError("WebSocket not connected")
+        msg = json.dumps(data)
+        asyncio.run_coroutine_threadsafe(self.ws.send(msg), self.loop)
+
+    async def stop(self) -> None:
+        if self.ws is not None:
+            await self.ws.close()
+        if self.on_disconnect:
+            self.on_disconnect()
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join()

--- a/ws_cross_mode_consistency.py
+++ b/ws_cross_mode_consistency.py
@@ -1,0 +1,42 @@
+import asyncio
+import json
+import websockets
+
+from ws_cross_mode_sim import CrossModeServer
+
+async def bot(name: str, host: str = "localhost", port: int = 8767):
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(json.dumps({"init": "bot"}))
+        for _ in range(2):
+            msg = json.loads(await ws.recv())
+            print(f"{name} received {msg}")
+            await ws.send(json.dumps({"ack": f"{name}:{msg['cmd']}"}))
+
+async def mcp(host: str = "localhost", port: int = 8767):
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(json.dumps({"init": "mcp"}))
+        for cmd in ["left", "right"]:
+            await ws.send(json.dumps({"cmd": cmd}))
+            ack = json.loads(await ws.recv())
+            print(f"MCP got {ack}")
+
+async def pygame_client(host: str = "localhost", port: int = 8767):
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(json.dumps({"init": "pygame"}))
+        await ws.send(json.dumps({"cmd": "jump"}))
+        await asyncio.sleep(0.1)
+
+async def main():
+    server = CrossModeServer()
+    await server.start()
+    await asyncio.gather(
+        bot("b1"),
+        bot("b2"),
+        mcp(),
+        pygame_client(),
+    )
+    await server.stop()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/ws_cross_mode_consistency_extended.py
+++ b/ws_cross_mode_consistency_extended.py
@@ -1,0 +1,40 @@
+import asyncio
+import json
+import websockets
+
+from ws_cross_mode_sim import CrossModeServer
+
+async def reconnecting_bots(host="localhost", port=8773):
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(json.dumps({"init": "bot"}))
+        msg = json.loads(await ws.recv())
+        print("first bot got", msg)
+        await ws.send(json.dumps({"ack": "first"}))
+    await asyncio.sleep(0.1)
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(json.dumps({"init": "bot"}))
+        msg = json.loads(await ws.recv())
+        print("second bot got", msg)
+        await ws.send(json.dumps({"ack": "second"}))
+
+async def multiple_mcps(host="localhost", port=8773):
+    async with websockets.connect(f"ws://{host}:{port}") as ws1, \
+        websockets.connect(f"ws://{host}:{port}") as ws2:
+        await ws1.send(json.dumps({"init": "mcp"}))
+        await ws2.send(json.dumps({"init": "mcp"}))
+        await ws1.send(json.dumps({"cmd": "a"}))
+        await ws2.send(json.dumps({"cmd": "b"}))
+        for ws in (ws1, ws2):
+            for _ in range(2):
+                msg = json.loads(await ws.recv())
+                print("mcp got", msg)
+
+async def main():
+    server = CrossModeServer(host="localhost", port=8773)
+    await server.start()
+    await asyncio.gather(reconnecting_bots(), multiple_mcps())
+    await server.stop()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/ws_cross_mode_sim.py
+++ b/ws_cross_mode_sim.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+from typing import Set
+import websockets
+
+class CrossModeServer:
+    def __init__(self, host: str = "localhost", port: int = 8767) -> None:
+        self.host = host
+        self.port = port
+        self.bot_clients: Set[websockets.WebSocketServerProtocol] = set()
+        self.mcp_clients: Set[websockets.WebSocketServerProtocol] = set()
+        self.pygame_clients: Set[websockets.WebSocketServerProtocol] = set()
+        self._server = None
+
+    async def start(self) -> None:
+        self._server = await websockets.serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handler(self, websocket):
+        try:
+            async for raw in websocket:
+                message = json.loads(raw)
+                if message.get("init") == "bot":
+                    self.bot_clients.add(websocket)
+                    continue
+                if message.get("init") == "mcp":
+                    self.mcp_clients.add(websocket)
+                    continue
+                if message.get("init") == "pygame":
+                    self.pygame_clients.add(websocket)
+                    continue
+                if websocket in self.bot_clients:
+                    for client in list(self.mcp_clients):
+                        if client.open:
+                            await client.send(raw)
+                elif websocket in self.mcp_clients or websocket in self.pygame_clients:
+                    for client in list(self.bot_clients):
+                        if client.open:
+                            await client.send(raw)
+        finally:
+            for s in (self.bot_clients, self.mcp_clients, self.pygame_clients):
+                s.discard(websocket)
+


### PR DESCRIPTION
## Summary
- test parser handling for multiple day lines and trailing whitespace
- cover more server cases: multiple MCP clients and bot reconnects
- demo reconnecting bots and multiple MCPs in `ws_cross_mode_consistency_extended.py`
- document how these tests relate to the consistency question

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848820b43f88325bb7a1bae98399fa6